### PR TITLE
week3/issue#28 Feat: 사용자 참여 서비스 내역 조회 API 구현

### DIFF
--- a/src/main/java/teamssavice/ssavice/book/constants/BookStatus.java
+++ b/src/main/java/teamssavice/ssavice/book/constants/BookStatus.java
@@ -1,0 +1,17 @@
+package teamssavice.ssavice.book.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BookStatus {
+
+    APPLYING("모집 신청 중"),  // 아직 인원이 안 모였거나 마감 전
+    MATCHED("모집 성공"),     // 확정: 최소 인원이 모여서 공구 성사됨
+    FAILED("모집 무산"),      // 실패: 기간 내 인원 미달로 취소됨
+    CANCELED("신청 취소"),    // 취소: 사용자가 직접 취소함
+    COMPLETED("이용 완료");   // 완료: 서비스 이용이 끝남 (리뷰 작성 가능 상태)
+
+    private final String description;
+}

--- a/src/main/java/teamssavice/ssavice/book/controller/BookController.java
+++ b/src/main/java/teamssavice/ssavice/book/controller/BookController.java
@@ -1,0 +1,43 @@
+package teamssavice.ssavice.book.controller;
+
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import teamssavice.ssavice.auth.constants.Role;
+import teamssavice.ssavice.book.controller.dto.BookResponse;
+import teamssavice.ssavice.book.service.BookService;
+import teamssavice.ssavice.book.service.dto.BookCommand;
+import teamssavice.ssavice.book.service.dto.BookModel;
+import teamssavice.ssavice.global.annotation.CurrentId;
+import teamssavice.ssavice.global.annotation.RequireRole;
+
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+@RequireRole(Role.USER)
+public class BookController {
+
+    private final BookService bookService;
+
+    @GetMapping("/book")
+    public ResponseEntity<Page<BookResponse.Info>> getMyBook(
+            @CurrentId Long userId,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+
+        System.out.println(userId);
+        BookCommand.Retrieve command = BookCommand.Retrieve.of(userId, pageable);
+
+        Page<BookModel.Info> models = bookService.getMyBooks(command);
+
+        return ResponseEntity.ok(models.map(BookResponse.Info::from));
+    }
+}

--- a/src/main/java/teamssavice/ssavice/book/controller/BookController.java
+++ b/src/main/java/teamssavice/ssavice/book/controller/BookController.java
@@ -17,6 +17,7 @@ import teamssavice.ssavice.book.service.dto.BookCommand;
 import teamssavice.ssavice.book.service.dto.BookModel;
 import teamssavice.ssavice.global.annotation.CurrentId;
 import teamssavice.ssavice.global.annotation.RequireRole;
+import teamssavice.ssavice.global.dto.PageResponse;
 
 
 @RestController
@@ -28,16 +29,16 @@ public class BookController {
     private final BookService bookService;
 
     @GetMapping("/book")
-    public ResponseEntity<Page<BookResponse.Info>> getMyBook(
+    public ResponseEntity<PageResponse<BookResponse.Info>> getMyBook(
             @CurrentId Long userId,
             @PageableDefault(size = 10) Pageable pageable
     ) {
 
-        System.out.println(userId);
         BookCommand.Retrieve command = BookCommand.Retrieve.of(userId, pageable);
 
         Page<BookModel.Info> models = bookService.getMyBooks(command);
+        Page<BookResponse.Info> reponsePage = models.map(BookResponse.Info::from);
 
-        return ResponseEntity.ok(models.map(BookResponse.Info::from));
+        return ResponseEntity.ok(PageResponse.from(reponsePage));
     }
 }

--- a/src/main/java/teamssavice/ssavice/book/controller/dto/BookResponse.java
+++ b/src/main/java/teamssavice/ssavice/book/controller/dto/BookResponse.java
@@ -1,0 +1,77 @@
+package teamssavice.ssavice.book.controller.dto;
+
+import teamssavice.ssavice.book.service.dto.BookModel;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class BookResponse {
+
+    public record Info(
+            ServiceInfo serviceInfo,
+            String bookStatus,
+            boolean isReviewed
+    ) {
+        public static Info from (BookModel.Info model) {
+            return new Info(
+                    ServiceInfo.from(model.serviceDetail()),
+                    model.bookStatus().name(),
+                    model.isReviewed()
+            );
+        }
+    }
+
+    public record ServiceInfo(
+            Long serviceId,
+            String thumbnailUrl,
+            String category,
+            String companyName,
+            Long companyId,
+            String title,
+            // 위치 정보
+            BigDecimal latitude,
+            BigDecimal longitude,
+            String region1,
+            String region2,
+            // 인원
+            Long currentMember,
+            Long minimumMember,
+            Long maximumMember,
+            // 가격
+            Long basePrice,
+            Integer discountRate,
+            Long discountedPrice,
+            // 기타
+            LocalDateTime deadline,
+            String tag,
+            String status
+    ) {
+        public static ServiceInfo from(BookModel.ServiceDetail model) {
+            return new ServiceInfo(
+                    model.serviceId(),
+                    model.imageUrl(), // Model의 필드명(thumbnailUrl 등)을 가져옴
+                    model.category(),
+                    model.companyName(),
+                    model.companyId(),
+                    model.title(),
+
+                    model.latitude(),
+                    model.longitude(),
+                    model.region1(),
+                    model.region2(),
+
+                    model.currentMember(),
+                    model.minMember(),
+                    model.maxMember(),
+
+                    model.basePrice(),
+                    model.discountRate(),
+                    model.discountedPrice(),
+
+                    model.deadline(),
+                    model.tags(), // List<String> 그대로 전달
+                    model.status()
+            );
+        }
+    }
+}

--- a/src/main/java/teamssavice/ssavice/book/entity/Book.java
+++ b/src/main/java/teamssavice/ssavice/book/entity/Book.java
@@ -1,0 +1,39 @@
+package teamssavice.ssavice.book.entity;
+
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import teamssavice.ssavice.book.constants.BookStatus;
+import teamssavice.ssavice.global.entity.BaseEntity;
+import teamssavice.ssavice.serviceItem.entity.ServiceItem;
+import teamssavice.ssavice.user.entity.Users;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+@AllArgsConstructor
+public class Book extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "serviceItem_id", nullable = false)
+    private ServiceItem serviceItem;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private BookStatus bookStatus;
+
+    @NotNull
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean isReviewed = false;
+}

--- a/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
+++ b/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
@@ -1,0 +1,23 @@
+package teamssavice.ssavice.book.infrastructure.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import teamssavice.ssavice.book.entity.Book;
+
+
+@Repository
+public interface BookRepository extends JpaRepository<Book, Long> {
+
+    @Query("SELECT b FROM Book b " +
+            "JOIN FETCH b.user " +
+            "JOIN FETCH b.serviceItem s " +
+            "JOIN FETCH s.company " +
+            "JOIN FETCH s.address " +
+            "WHERE b.user.id = :userId")
+    Page<Book> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
+
+}

--- a/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
+++ b/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
@@ -12,12 +12,13 @@ import teamssavice.ssavice.book.entity.Book;
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
 
-    @Query("SELECT b FROM Book b " +
+    @Query(value = "SELECT b FROM Book b " +
             "JOIN FETCH b.user " +
             "JOIN FETCH b.serviceItem s " +
             "JOIN FETCH s.company " +
             "JOIN FETCH s.address " +
-            "WHERE b.user.id = :userId")
-    Page<Book> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
+            "WHERE b.user.id = :userId",
 
+            countQuery = "SELECT count(b) FROM Book b WHERE b.user.id = :userId")
+    Page<Book> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
@@ -1,0 +1,24 @@
+package teamssavice.ssavice.book.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamssavice.ssavice.book.entity.Book;
+import teamssavice.ssavice.book.infrastructure.repository.BookRepository;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BookReadService {
+
+    private final BookRepository bookRepository;
+
+    public Page<Book> findAllByUserId(Long userId, Pageable pageable) {
+
+        return bookRepository.findAllByUserId(userId, pageable);
+    }
+}

--- a/src/main/java/teamssavice/ssavice/book/service/BookService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookService.java
@@ -1,0 +1,25 @@
+package teamssavice.ssavice.book.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import teamssavice.ssavice.book.entity.Book;
+import teamssavice.ssavice.book.service.dto.BookCommand;
+import teamssavice.ssavice.book.service.dto.BookModel;
+
+@Service
+@RequiredArgsConstructor
+public class BookService {
+
+    private final BookReadService bookReadService;
+
+
+    public Page<BookModel.Info> getMyBooks(BookCommand.Retrieve command) {
+        Page<Book> books = bookReadService.findAllByUserId(command.userId(), command.pageable());
+
+        return books.map(BookModel.Info::from);
+    }
+}
+
+

--- a/src/main/java/teamssavice/ssavice/book/service/BookWriteService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookWriteService.java
@@ -1,0 +1,10 @@
+package teamssavice.ssavice.book.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookWriteService {
+}

--- a/src/main/java/teamssavice/ssavice/book/service/dto/BookCommand.java
+++ b/src/main/java/teamssavice/ssavice/book/service/dto/BookCommand.java
@@ -1,0 +1,16 @@
+package teamssavice.ssavice.book.service.dto;
+
+
+import org.springframework.data.domain.Pageable;
+
+public class BookCommand {
+
+    public record Retrieve(
+            Long userId,
+            Pageable pageable
+    ) {
+        public static Retrieve of(Long userId, Pageable pageable) {
+            return new Retrieve(userId, pageable);
+        }
+    }
+}

--- a/src/main/java/teamssavice/ssavice/book/service/dto/BookModel.java
+++ b/src/main/java/teamssavice/ssavice/book/service/dto/BookModel.java
@@ -1,0 +1,80 @@
+package teamssavice.ssavice.book.service.dto;
+import teamssavice.ssavice.book.constants.BookStatus;
+import teamssavice.ssavice.book.entity.Book;
+import teamssavice.ssavice.serviceItem.entity.ServiceItem;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class BookModel {
+
+    public record Info(
+            Long bookId,
+            BookStatus bookStatus,
+            boolean isReviewed,
+            ServiceDetail serviceDetail
+    ) {
+        public static Info from(Book book) {
+            return new Info(
+                    book.getId(),
+                    book.getBookStatus(),
+                    book.isReviewed(),
+                    ServiceDetail.from(book.getServiceItem())
+            );
+        }
+    }
+
+    public record ServiceDetail(
+            Long serviceId,
+            String title,
+            String imageUrl,
+            String category,
+            String companyName,
+            Long companyId,
+
+            String region1,
+            String region2,
+            BigDecimal latitude,
+            BigDecimal longitude,
+
+            Long currentMember,
+            Long minMember,
+            Long maxMember,
+            Long basePrice,
+            Integer discountRate,
+            Long discountedPrice,
+
+            LocalDateTime deadline,
+            String tags,
+            String status
+    ) {
+        public static ServiceDetail from(ServiceItem item) {
+
+            return new ServiceDetail(
+                    item.getId(),
+                    item.getTitle(),
+                    item.getThumbnailUrl(),
+                    item.getCategory(),
+
+                    item.getCompany().getCompanyName(),
+                    item.getCompany().getId(),
+                    item.getAddress().getRegion1(),
+                    item.getAddress().getRegion2(),
+                    item.getAddress().getLatitude(),
+                    item.getAddress().getLongitude(),
+
+                    item.getCurrentMember(),
+                    item.getMinimumMember(),
+                    item.getMaximumMember(),
+
+                    item.getPrice().getBasePrice(),
+                    item.getPrice().getDiscountRate(),
+                    item.getPrice().getDiscountedPrice(),
+
+                    item.getDeadline(),
+                    item.getTag(),
+                    item.getStatus().name()
+            );
+        }
+    }
+}

--- a/src/main/java/teamssavice/ssavice/global/dto/PageResponse.java
+++ b/src/main/java/teamssavice/ssavice/global/dto/PageResponse.java
@@ -1,0 +1,22 @@
+package teamssavice.ssavice.global.dto;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int currentPage,
+        int totalPages,
+        long totalElements,
+        int size
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getTotalPages(),
+                page.getTotalElements(),
+                page.getSize()
+        );
+    }
+}

--- a/src/main/java/teamssavice/ssavice/serviceItem/entity/ServiceItem.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/entity/ServiceItem.java
@@ -67,8 +67,6 @@ public class ServiceItem extends BaseEntity {
 
     private String tag; // 엘라스틱 서치 도입 예정
 
-    private String ThumbnailUrl;
-
     @Builder.Default
     @Column(nullable = false)
     private boolean isDeleted = false;

--- a/src/main/java/teamssavice/ssavice/serviceItem/entity/ServiceItem.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/entity/ServiceItem.java
@@ -17,6 +17,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class ServiceItem extends BaseEntity {
 
+    private static final String DEFAULT_IMAGE_URL = "https://placehold.co/400x400?text=SSAVICE";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -68,6 +70,11 @@ public class ServiceItem extends BaseEntity {
     @Builder.Default
     @Column(nullable = false)
     private boolean isDeleted = false;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private String thumbnailUrl = DEFAULT_IMAGE_URL;
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_id", nullable = false)

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,8 @@
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:ssavice;MODE=MySQL
+spring.datasource.username=user
+spring.sql.init.mode=always
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.defer-datasource-initialization=true
+spring.jpa.hibernate.ddl-auto=create


### PR DESCRIPTION
## 🔎 작업 내용
Book 엔티티 생성 및 연관관계 매핑 (User, ServiceItem)

공구 상태 관리를 위한 Status Enum 정의

(APPLYING, MATCHED, FAILED, CANCELED, COMPLETED)

ServiceItem 엔티티에 썸네일 이미지 URL 필드 추가 및 기본값 설정

사용자 참여 서비스 내역 조회 API 구현

페이징 처리를 위한 공통 DTO

## 이미지 첨부

<!--- 
관련 이미지가 있다면 첨부해주세요.
복잡한 도메인로직이 있다면 플로우차트로 표현해주세요.
--->

## To Reviewers 📢
<!-- 리뷰어에게 질문할 사항이나 추가 설명, 요청이 필요한 부분을 여기에 적어주세요. -->

## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [X] 테스트를 통과했습니다.
- [X] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #28
