### PR TITLE
Week5/issue#64 Swagger에 enum 정리, ErrorMassage에 가능한 값 목록 반환, status ALL 추가

### DIFF
--- a/src/main/java/teamssavice/ssavice/book/controller/BookController.java
+++ b/src/main/java/teamssavice/ssavice/book/controller/BookController.java
@@ -2,7 +2,6 @@ package teamssavice.ssavice.book.controller;
 
 
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -12,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import teamssavice.ssavice.auth.constants.Role;
-import teamssavice.ssavice.book.constants.BookStatus;
+import teamssavice.ssavice.book.controller.dto.BookRequest.BookStatusFilter;
 import teamssavice.ssavice.book.controller.dto.BookResponse;
 import teamssavice.ssavice.book.service.BookService;
 import teamssavice.ssavice.book.service.dto.BookCommand;
@@ -34,11 +33,11 @@ public class BookController {
     public ResponseEntity<PageResponse<BookResponse.Info>> getMyBooksByStatus(
         @CurrentId Long userId,
         @PageableDefault(size = 10) Pageable pageable,
-        @RequestParam(required = false) BookStatus status
+        @RequestParam BookStatusFilter status
     ) {
 
         BookCommand.RetrieveByStatus command = BookCommand.RetrieveByStatus.of(userId, pageable,
-            status);
+            status.toDomainOrNull());
 
         Page<BookModel.Info> models = bookService.getMyBooksByStatue(command);
         Page<BookResponse.Info> reponsePage = models.map(BookResponse.Info::from);

--- a/src/main/java/teamssavice/ssavice/book/controller/dto/BookRequest.java
+++ b/src/main/java/teamssavice/ssavice/book/controller/dto/BookRequest.java
@@ -1,0 +1,19 @@
+package teamssavice.ssavice.book.controller.dto;
+
+import teamssavice.ssavice.book.constants.BookStatus;
+
+public class BookRequest {
+
+    public enum BookStatusFilter {
+        ALL,
+        APPLYING,
+        MATCHED,
+        FAILED,
+        CANCELED,
+        COMPLETED;
+
+        public BookStatus toDomainOrNull() {
+            return this == ALL ? null : BookStatus.valueOf(this.name());
+        }
+    }
+}

--- a/src/main/java/teamssavice/ssavice/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/teamssavice/ssavice/global/exception/GlobalExceptionHandler.java
@@ -54,7 +54,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ProblemDetail> missingServletRequestParameterException(
-            MissingServletRequestParameterException e
+        MissingServletRequestParameterException e
     ) {
         ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
         problemDetail.setTitle("Missing Request Parameter");
@@ -74,7 +74,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<ProblemDetail> httpRequestMethodNotSupportedException(
-            HttpRequestMethodNotSupportedException e
+        HttpRequestMethodNotSupportedException e
     ) {
         ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.METHOD_NOT_ALLOWED);
         problemDetail.setTitle("Method Not Allowed");
@@ -112,6 +112,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ConflictException.class)
     public ResponseEntity<ProblemDetail> conflictException(ConflictException e) {
         ProblemDetail problemDetail = setCustomProblemDetail(e);
+        return ResponseEntity.status(problemDetail.getStatus()).body(problemDetail);
+    }
+
+    @ExceptionHandler(UnsupportedImageContentTypeException.class)
+    public ResponseEntity<ProblemDetail> unsupportedImageContentTypeException(
+        UnsupportedImageContentTypeException e) {
+        ProblemDetail problemDetail = setCustomProblemDetail(e);
+        problemDetail.setProperty("invalid_value", e.getInvalidValue());
+        problemDetail.setProperty("allowed_values", e.getAllowedValues());
         return ResponseEntity.status(problemDetail.getStatus()).body(problemDetail);
     }
 

--- a/src/main/java/teamssavice/ssavice/global/exception/UnsupportedImageContentTypeException.java
+++ b/src/main/java/teamssavice/ssavice/global/exception/UnsupportedImageContentTypeException.java
@@ -5,8 +5,24 @@ import teamssavice.ssavice.global.constants.ErrorCode;
 public class UnsupportedImageContentTypeException extends CustomException {
 
     private static final String DEFAULT_TITLE = "Validation Error";
+    private final String invalidValue;
+    private final String[] allowedValues;
 
-    public UnsupportedImageContentTypeException(ErrorCode errorCode) {
+    public UnsupportedImageContentTypeException(
+        ErrorCode errorCode,
+        String invalidValue,
+        String[] allowedValues
+    ) {
         super(errorCode, DEFAULT_TITLE);
+        this.invalidValue = invalidValue;
+        this.allowedValues = allowedValues;
+    }
+
+    public String getInvalidValue() {
+        return invalidValue;
+    }
+
+    public String[] getAllowedValues() {
+        return allowedValues;
     }
 }

--- a/src/main/java/teamssavice/ssavice/imageresource/ImageRequest.java
+++ b/src/main/java/teamssavice/ssavice/imageresource/ImageRequest.java
@@ -1,32 +1,39 @@
 package teamssavice.ssavice.imageresource;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
-
 import java.util.List;
+import lombok.Builder;
 
 public class ImageRequest {
 
     @Builder
     public record ServiceImages(
-            @NotNull
-            @Valid
-            List<ContentType> add
+        @NotNull
+        @Valid
+        List<ContentType> add
     ) {
+
     }
 
     @Builder
     public record ContentType(
-            @NotNull
-            String contentType
+        @NotNull
+        @Schema(
+            description = "지원 MIME 타입: image/jpeg, image/png, image/webp",
+            example = "image/jpeg,image/png,image/webp"
+        )
+        String contentType
     ) {
+
     }
 
     @Builder
     public record Confirm(
-            @NotNull
-            String objectKey
-    ){
+        @NotNull
+        String objectKey
+    ) {
+
     }
 }

--- a/src/main/java/teamssavice/ssavice/imageresource/constants/ImageContentType.java
+++ b/src/main/java/teamssavice/ssavice/imageresource/constants/ImageContentType.java
@@ -1,9 +1,8 @@
 package teamssavice.ssavice.imageresource.constants;
 
+import java.util.Arrays;
 import teamssavice.ssavice.global.constants.ErrorCode;
 import teamssavice.ssavice.global.exception.UnsupportedImageContentTypeException;
-
-import java.util.Arrays;
 
 public enum ImageContentType {
 
@@ -19,24 +18,33 @@ public enum ImageContentType {
         this.extension = extension;
     }
 
-    public String mimeType() {
-        return mimeType;
-    }
-
-    public String extension() {
-        return extension;
+    // 에러/문서용: 허용 mimeType 목록
+    public static String[] allowedMimeTypes() {
+        return Arrays.stream(values())
+            .map(ImageContentType::mimeType)
+            .toArray(String[]::new);
     }
 
     public static ImageContentType from(String input) {
         String normalized = normalize(input);
 
         return Arrays.stream(values())
-                .filter(it -> it.mimeType.equals(normalized))
-                .findFirst()
-                .orElseThrow(() -> new UnsupportedImageContentTypeException(ErrorCode.UNSUPPORTED_IMAGE_CONTENT_TYPE));
+            .filter(it -> it.mimeType.equals(normalized))
+            .findFirst()
+            .orElseThrow(() -> new UnsupportedImageContentTypeException(
+                ErrorCode.UNSUPPORTED_IMAGE_CONTENT_TYPE, input,
+                allowedMimeTypes()));
     }
 
     private static String normalize(String input) {
         return input.split(";")[0].trim().toLowerCase();
+    }
+
+    public String mimeType() {
+        return mimeType;
+    }
+
+    public String extension() {
+        return extension;
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용
- Swagger에 가능한 Enum값 보여주기
- 에러 메세지에 가능한 Enum값 넘기기
- 옵션에 ALL값 추가

## 이미지 첨부

<!--- 
관련 이미지가 있다면 첨부해주세요.
복잡한 도메인로직이 있다면 플로우차트로 표현해주세요.
--->

## To Reviewers 📢
<!-- 리뷰어에게 질문할 사항이나 추가 설명, 요청이 필요한 부분을 여기에 적어주세요. -->

## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [x] 테스트를 통과했습니다.
- [x] API 변경사항이 존재합니다.
- [x] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [x] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #64 
