### PR TITLE
Week6/issue#78 서비스 검색 API 변경 및 ServiceItem 상태와 BookStatus 상태 재정의

### DIFF
--- a/src/main/java/teamssavice/ssavice/book/constants/BookStatusFilter.java
+++ b/src/main/java/teamssavice/ssavice/book/constants/BookStatusFilter.java
@@ -1,0 +1,9 @@
+package teamssavice.ssavice.book.constants;
+
+public enum BookStatusFilter {
+    // 전체
+    ALL,
+    RECRUITING, // 모집중: RECRUITING, SUCCEEDED
+    COMPLETED,  // 모집완료: FULLED, IN_USE, COMPLETED
+    CANCELED    // 취소: FAILED, CANCELED
+}

--- a/src/main/java/teamssavice/ssavice/book/constants/BookViewStatus.java
+++ b/src/main/java/teamssavice/ssavice/book/constants/BookViewStatus.java
@@ -1,0 +1,14 @@
+package teamssavice.ssavice.book.constants;
+
+public enum BookViewStatus {
+    RECRUITING,
+    SUCCEEDED,
+
+    FULLED,
+    IN_USE,
+    COMPLETED,
+
+    FAILED,
+    SERVICE_CANCELED,
+    USER_CANCELED
+}

--- a/src/main/java/teamssavice/ssavice/book/controller/BookController.java
+++ b/src/main/java/teamssavice/ssavice/book/controller/BookController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import teamssavice.ssavice.auth.constants.Role;
-import teamssavice.ssavice.book.controller.dto.BookRequest.BookStatusFilter;
+import teamssavice.ssavice.book.constants.BookStatusFilter;
 import teamssavice.ssavice.book.controller.dto.BookResponse;
 import teamssavice.ssavice.book.service.BookService;
 import teamssavice.ssavice.book.service.dto.BookCommand;
@@ -36,8 +36,7 @@ public class BookController {
         @RequestParam BookStatusFilter status
     ) {
 
-        BookCommand.RetrieveByStatus command = BookCommand.RetrieveByStatus.of(userId, pageable,
-            status.toDomainOrNull());
+        BookCommand.RetrieveByStatus command = BookCommand.RetrieveByStatus.of(userId, pageable, status);
 
         Page<BookModel.Info> models = bookService.getMyBooksByStatus(command);
         Page<BookResponse.Info> reponsePage = models.map(BookResponse.Info::from);

--- a/src/main/java/teamssavice/ssavice/book/controller/dto/BookRequest.java
+++ b/src/main/java/teamssavice/ssavice/book/controller/dto/BookRequest.java
@@ -1,19 +1,5 @@
 package teamssavice.ssavice.book.controller.dto;
 
-import teamssavice.ssavice.book.constants.BookStatus;
-
 public class BookRequest {
 
-    public enum BookStatusFilter {
-        ALL,
-        APPLYING,
-        MATCHED,
-        FAILED,
-        CANCELED,
-        COMPLETED;
-
-        public BookStatus toDomainOrNull() {
-            return this == ALL ? null : BookStatus.valueOf(this.name());
-        }
-    }
 }

--- a/src/main/java/teamssavice/ssavice/book/controller/dto/BookResponse.java
+++ b/src/main/java/teamssavice/ssavice/book/controller/dto/BookResponse.java
@@ -1,18 +1,15 @@
 package teamssavice.ssavice.book.controller.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import teamssavice.ssavice.address.AddressResponse;
-import teamssavice.ssavice.book.constants.BookStatus;
 import teamssavice.ssavice.book.service.dto.BookModel;
-import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 
 import java.time.LocalDateTime;
 
 public class BookResponse {
 
     public record Info(
-        ServiceInfo serviceInfo,
+        ServiceInfo service,
         String bookStatus,
         boolean isReviewed
     ) {
@@ -45,8 +42,7 @@ public class BookResponse {
         Long discountedPrice,
         // 기타
         LocalDateTime deadline,
-        String tag,
-        String status
+        String tag
     ) {
 
         public static ServiceInfo from(BookModel.ServiceDetail model) {
@@ -69,8 +65,7 @@ public class BookResponse {
                 model.discountedPrice(),
 
                 model.deadline(),
-                model.tags(), // List<String> 그대로 전달
-                model.status()
+                model.tags() // List<String> 그대로 전달
             );
         }
     }
@@ -100,51 +95,5 @@ public class BookResponse {
                     .bookId(model.bookId())
                     .build();
         }
-    }
-
-//    // 여러 상태를 위해서 만들어둠
-//    private static DisplayStatus toDisplayStatus() {
-//        if (model.bookStatus() == BookStatus.CANCELED) {
-//            return new DisplayStatus(DisplayStatusCode.USER_CANCELED, "유저 취소");
-//        }
-//
-//        return switch (model.serviceStatus()) {
-//            case RECRUITING ->
-//                    new DisplayStatus(DisplayStatusCode.RECRUITING, "모집 중 (취소 가능)");
-//
-//            case FAILED ->
-//                    new DisplayStatus(DisplayStatusCode.FAILED, "모집 실패");
-//
-//            case CANCELED ->
-//                    new DisplayStatus(DisplayStatusCode.SERVICE_CANCELED, "업체 취소");
-//            // 이 부분 관련해서 스케줄러 도입 예정 - ServiceStatus 에서
-//            case COMPLETED ->
-//                    new DisplayStatus(DisplayStatusCode.COMPLETED, "이용 완료 (리뷰 작성 가능)");
-//
-//            case SUCCEEDED, FULLED -> {
-//                if (model.isInUse()) {
-//                    yield new DisplayStatus(DisplayStatusCode.IN_USE, "이용 중");
-//                }
-//
-//                if (model.isTimeOver()) {
-//                    yield new DisplayStatus(DisplayStatusCode.COMPLETED, "이용 완료 (리뷰 작성 가능)");
-//                }
-//
-//                yield (model.serviceStatus() == ServiceStatus.SUCCEEDED)
-//                        ? new DisplayStatus(DisplayStatusCode.SUCCEEDED, "모집 성공 (취소 불가능)")
-//                        : new DisplayStatus(DisplayStatusCode.FULLED, "모집 마감");
-//            }
-//        };
-//    }
-
-    public record DisplayStatus(
-            DisplayStatusCode code, // 프론트 로직용
-            @Schema(description = "상태 라벨", example = "모집 중")
-            String label  // 화면 출력용
-    ) {
-    }
-
-    public enum DisplayStatusCode {
-        RECRUITING, SUCCEEDED, FULLED, IN_USE, FAILED, COMPLETED, SERVICE_CANCELED, USER_CANCELED
     }
 }

--- a/src/main/java/teamssavice/ssavice/book/entity/Book.java
+++ b/src/main/java/teamssavice/ssavice/book/entity/Book.java
@@ -4,7 +4,6 @@ package teamssavice.ssavice.book.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-import teamssavice.ssavice.book.constants.BookStatus;
 import teamssavice.ssavice.global.entity.BaseEntity;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 import teamssavice.ssavice.user.entity.Users;

--- a/src/main/java/teamssavice/ssavice/book/entity/BookStatus.java
+++ b/src/main/java/teamssavice/ssavice/book/entity/BookStatus.java
@@ -1,4 +1,4 @@
-package teamssavice.ssavice.book.constants;
+package teamssavice.ssavice.book.entity;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
+++ b/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
@@ -3,13 +3,13 @@ package teamssavice.ssavice.book.infrastructure.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import teamssavice.ssavice.book.constants.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
-import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
+
+import java.util.List;
 
 
 @Repository
@@ -39,26 +39,14 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     )
     Page<Book> findAllByUserIdAndStatus(Long userId, BookStatus status, Pageable pageable);
 
-    @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE Book b SET b.bookStatus = :targetStatus " +
-            "WHERE b.serviceItem.id = :serviceId " +
-            "AND b.bookStatus = :currentStatus")
-    int updateStatusByServiceId(
-            @Param("serviceId") Long serviceId,
-            @Param("currentStatus") BookStatus currentStatus,
-            @Param("targetStatus") BookStatus targetStatus
-    );
-
     boolean existsByUserIdAndServiceItemIdAndBookStatusNot(Long userId, Long serviceItemId, BookStatus bookStatus);
 
-    @Query("SELECT COUNT(b) FROM Book b " +
+    @Query("SELECT b FROM Book b " +
             "JOIN b.serviceItem s " + // 페치 조인이 아닌 일반 조인
             "WHERE b.user.id = :userId " +
-            "AND b.bookStatus = :bookStatus " +
-            "AND s.status = :serviceStatus")
-    Long countByUserIdAndBookStatusAndServiceStatus(
+            "AND b.bookStatus = :bookStatus")
+    List<Book> findByUserIdAndBookStatus(
             @Param("userId") Long userId,
-            @Param("bookStatus") BookStatus bookStatus,
-            @Param("serviceStatus") ServiceStatus serviceStatus
+            @Param("bookStatus") BookStatus bookStatus
     );
 }

--- a/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
+++ b/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
@@ -1,43 +1,17 @@
 package teamssavice.ssavice.book.infrastructure.repository;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import teamssavice.ssavice.book.constants.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
+import teamssavice.ssavice.book.entity.BookStatus;
 
 import java.util.List;
 
 
 @Repository
-public interface BookRepository extends JpaRepository<Book, Long> {
-
-    @Query(value = "SELECT b FROM Book b " +
-            "JOIN FETCH b.user " +
-            "JOIN FETCH b.serviceItem s " +
-            "JOIN FETCH s.company " +
-            "JOIN FETCH s.address " +
-            "WHERE b.user.id = :userId",
-
-            countQuery = "SELECT count(b) FROM Book b WHERE b.user.id = :userId")
-    Page<Book> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
-
-    @Query(
-        value = "SELECT b FROM Book b " +
-            "JOIN FETCH b.user " +
-            "JOIN FETCH b.serviceItem s " +
-            "JOIN FETCH s.company " +
-            "JOIN FETCH s.address " +
-            "WHERE b.user.id = :userId " +
-            "AND (:status IS NULL OR b.bookStatus = :status)",
-        countQuery = "SELECT count(b) FROM Book b " +
-            "WHERE b.user.id = :userId " +
-            "AND (:status IS NULL OR b.bookStatus = :status)"
-    )
-    Page<Book> findAllByUserIdAndStatus(Long userId, BookStatus status, Pageable pageable);
+public interface BookRepository extends JpaRepository<Book, Long>, BookRepositoryCustom {
 
     boolean existsByUserIdAndServiceItemIdAndBookStatusNot(Long userId, Long serviceItemId, BookStatus bookStatus);
 

--- a/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryCustom.java
+++ b/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryCustom.java
@@ -1,0 +1,10 @@
+package teamssavice.ssavice.book.infrastructure.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import teamssavice.ssavice.book.constants.BookStatusFilter;
+import teamssavice.ssavice.book.entity.Book;
+
+public interface BookRepositoryCustom {
+    Page<Book> findAllByUserIdAndStatus(Long userId, BookStatusFilter status, Pageable pageable);
+}

--- a/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryImpl.java
+++ b/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryImpl.java
@@ -1,0 +1,88 @@
+package teamssavice.ssavice.book.infrastructure.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import teamssavice.ssavice.book.constants.BookStatusFilter;
+import teamssavice.ssavice.book.entity.Book;
+import teamssavice.ssavice.book.entity.BookStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static teamssavice.ssavice.address.QAddress.address1;
+import static teamssavice.ssavice.book.entity.QBook.book;
+import static teamssavice.ssavice.company.entity.QCompany.company;
+import static teamssavice.ssavice.serviceItem.entity.QServiceItem.serviceItem;
+
+@RequiredArgsConstructor
+public class BookRepositoryImpl implements BookRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Book> findAllByUserIdAndStatus(Long userId, BookStatusFilter status, Pageable pageable) {
+        LocalDateTime now = LocalDateTime.now();
+        BooleanExpression baseCondition = book.user.id.eq(userId);
+        BooleanExpression statusCondition = statusCondition(status, now);
+
+        List<Book> content = queryFactory
+                .selectFrom(book)
+                .join(book.serviceItem, serviceItem).fetchJoin()
+                .join(book.serviceItem.company, company).fetchJoin()
+                .join(book.serviceItem.address, address1).fetchJoin()
+                .where(
+                    baseCondition,
+                    statusCondition
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(book.createdAt.desc())
+                .fetch();
+
+        Long total = queryFactory
+                .select(book.count())
+                .from(book)
+                .where(
+                    baseCondition,
+                    statusCondition
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+
+    private BooleanExpression statusCondition(BookStatusFilter status, LocalDateTime now) {
+        if (status == null || status == BookStatusFilter.ALL) {
+            return null;
+        }
+
+        return switch (status) {
+            case RECRUITING -> serviceItem.isDeleted.isFalse()
+                    .and(book.bookStatus.eq(BookStatus.RESERVED))
+                    .and(serviceItem.currentMember.lt(serviceItem.maximumMember))
+                    .and(serviceItem.deadline.gt(now));
+
+            case CANCELED -> serviceItem.isDeleted.isTrue()
+                    .or(book.bookStatus.eq(BookStatus.CANCELED))
+                    .or(
+                        serviceItem.deadline.lt(now)
+                            .and(serviceItem.currentMember.lt(serviceItem.minimumMember))
+                    );
+
+            case COMPLETED -> serviceItem.isDeleted.isFalse()
+                    .and(book.bookStatus.eq(BookStatus.RESERVED))
+                    .and(
+                        serviceItem.currentMember.goe(serviceItem.maximumMember)
+                            .or(serviceItem.currentMember.goe(serviceItem.minimumMember)
+                                .and(serviceItem.deadline.lt(now))
+                            )
+                    );
+
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
@@ -6,7 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import teamssavice.ssavice.book.constants.BookStatus;
+import teamssavice.ssavice.book.constants.BookStatusFilter;
+import teamssavice.ssavice.book.entity.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.infrastructure.repository.BookRepository;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
@@ -22,12 +23,8 @@ public class BookReadService {
 
     private final BookRepository bookRepository;
 
-    public Page<Book> findAllByUserId(Long userId, Pageable pageable) {
+    public Page<Book> findAllByUserIdAndStatus(Long userId, BookStatusFilter status, Pageable pageable) {
 
-        return bookRepository.findAllByUserId(userId, pageable);
-    }
-
-    public Page<Book> findAllByUserIdAndStatus(Long userId, BookStatus status, Pageable pageable) {
         return bookRepository.findAllByUserIdAndStatus(userId, status, pageable);
     }
 

--- a/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
@@ -9,9 +9,10 @@ import org.springframework.transaction.annotation.Transactional;
 import teamssavice.ssavice.book.constants.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.infrastructure.repository.BookRepository;
-import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 import teamssavice.ssavice.user.entity.Users;
+
+import java.util.List;
 
 
 @Service
@@ -35,7 +36,7 @@ public class BookReadService {
         return bookRepository.existsByUserIdAndServiceItemIdAndBookStatusNot(user.getId(), serviceItem.getId(), BookStatus.CANCELED);
     }
 
-    public Long countByUserIdAndBookStatusAndServiceStatus(Long userId, BookStatus bookStatus, ServiceStatus serviceStatus) {
-        return bookRepository.countByUserIdAndBookStatusAndServiceStatus(userId, bookStatus, serviceStatus);
+    public List<Book> findByUserIdAndBookStatus(Long userId, BookStatus bookStatus) {
+        return bookRepository.findByUserIdAndBookStatus(userId, bookStatus);
     }
 }

--- a/src/main/java/teamssavice/ssavice/book/service/BookService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookService.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import teamssavice.ssavice.book.constants.BookStatus;
+import teamssavice.ssavice.book.entity.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.service.dto.BookCommand;
 import teamssavice.ssavice.book.service.dto.BookModel;
@@ -21,12 +21,8 @@ public class BookService {
 
     @Transactional(readOnly = true)
     public Page<BookModel.Info> getMyBooksByStatus(BookCommand.RetrieveByStatus command) {
-        Page<Book> books = bookReadService.findAllByUserIdAndStatus(
-            command.userId(),
-            command.status(),
-            command.pageable()
-        );
 
+        Page<Book> books = bookReadService.findAllByUserIdAndStatus(command.userId(), command.status(), command.pageable());
         return books.map(BookModel.Info::from);
     }
 

--- a/src/main/java/teamssavice/ssavice/book/service/BookService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookService.java
@@ -11,6 +11,8 @@ import teamssavice.ssavice.book.service.dto.BookCommand;
 import teamssavice.ssavice.book.service.dto.BookModel;
 import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class BookService {
@@ -30,21 +32,16 @@ public class BookService {
 
     @Transactional(readOnly = true)
     public BookModel.BookSummary getBookSummary(Long userId) {
+        List<Book> books = bookReadService.findByUserIdAndBookStatus(userId, BookStatus.RESERVED);
+        Long applying = 0L;
+        Long completedCount = 0L;
+        for (Book book : books) {
+            if(book.getServiceItem().getStatus() == ServiceStatus.RECRUITING) applying++;
+            else if(book.getServiceItem().getStatus() == ServiceStatus.SUCCEEDED ||
+                    book.getServiceItem().getStatus() == ServiceStatus.FULLED) completedCount++;
+        }
 
-        Long applying = bookReadService.countByUserIdAndBookStatusAndServiceStatus(
-                userId, BookStatus.RESERVED, ServiceStatus.RECRUITING
-        );
-
-        // 모집 성공
-        Long succeededCount = bookReadService.countByUserIdAndBookStatusAndServiceStatus(
-                userId, BookStatus.RESERVED, ServiceStatus.SUCCEEDED
-        );
-        // 모집 마감
-        Long closedCount = bookReadService.countByUserIdAndBookStatusAndServiceStatus(
-                userId, BookStatus.RESERVED, ServiceStatus.FULLED
-        );
-
-        return BookModel.BookSummary.from(applying, succeededCount + closedCount);
+        return BookModel.BookSummary.from(applying, completedCount);
     }
 }
 

--- a/src/main/java/teamssavice/ssavice/book/service/BookWriteService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookWriteService.java
@@ -4,7 +4,7 @@ package teamssavice.ssavice.book.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import teamssavice.ssavice.book.constants.BookStatus;
+import teamssavice.ssavice.book.entity.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.infrastructure.repository.BookRepository;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
@@ -17,11 +17,11 @@ public class BookWriteService {
 
     private final BookRepository bookRepository;
 
-    public Book save(Users user, ServiceItem serviceItem, BookStatus status) {
+    public Book apply(Users user, ServiceItem serviceItem) {
         Book book = Book.builder()
                 .user(user)
                 .serviceItem(serviceItem)
-                .bookStatus(status)
+                .bookStatus(BookStatus.RESERVED)
                 .build();
         return bookRepository.save(book);
     }

--- a/src/main/java/teamssavice/ssavice/book/service/dto/BookCommand.java
+++ b/src/main/java/teamssavice/ssavice/book/service/dto/BookCommand.java
@@ -3,7 +3,7 @@ package teamssavice.ssavice.book.service.dto;
 
 import lombok.Builder;
 import org.springframework.data.domain.Pageable;
-import teamssavice.ssavice.book.constants.BookStatus;
+import teamssavice.ssavice.book.constants.BookStatusFilter;
 
 public class BookCommand {
 
@@ -11,10 +11,10 @@ public class BookCommand {
     public record RetrieveByStatus(
         Long userId,
         Pageable pageable,
-        BookStatus status
+        BookStatusFilter status
     ) {
 
-        public static RetrieveByStatus of(Long userId, Pageable pageable, BookStatus status) {
+        public static RetrieveByStatus of(Long userId, Pageable pageable, BookStatusFilter status) {
             return RetrieveByStatus.builder()
                 .userId(userId)
                 .pageable(pageable)
@@ -22,4 +22,5 @@ public class BookCommand {
                 .build();
         }
     }
+
 }

--- a/src/main/java/teamssavice/ssavice/book/service/dto/BookModel.java
+++ b/src/main/java/teamssavice/ssavice/book/service/dto/BookModel.java
@@ -2,8 +2,10 @@ package teamssavice.ssavice.book.service.dto;
 
 import lombok.Builder;
 import teamssavice.ssavice.address.AddressModel;
-import teamssavice.ssavice.book.constants.BookStatus;
+import teamssavice.ssavice.book.constants.BookViewStatus;
+import teamssavice.ssavice.book.entity.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
+import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 
 import java.time.LocalDateTime;
@@ -12,7 +14,7 @@ public class BookModel {
 
     public record Info(
         Long bookId,
-        BookStatus bookStatus,
+        BookViewStatus bookStatus,
         boolean isReviewed,
         ServiceDetail serviceDetail
     ) {
@@ -20,10 +22,23 @@ public class BookModel {
         public static Info from(Book book) {
             return new Info(
                 book.getId(),
-                book.getBookStatus(),
+                resolve(book.getBookStatus(), book.getServiceItem().getStatus()),
                 book.isReviewed(),
                 ServiceDetail.from(book.getServiceItem())
             );
+        }
+
+        public static BookViewStatus resolve(BookStatus bookstatus, ServiceStatus serviceStatus) {
+            if(bookstatus == BookStatus.CANCELED) return BookViewStatus.USER_CANCELED;
+            return switch (serviceStatus) {
+                case RECRUITING -> BookViewStatus.RECRUITING;
+                case SUCCEEDED -> BookViewStatus.SUCCEEDED;
+                case FULLED -> BookViewStatus.FULLED;
+                case IN_USE -> BookViewStatus.IN_USE;
+                case COMPLETED -> BookViewStatus.COMPLETED;
+                case FAILED -> BookViewStatus.FAILED;
+                case CANCELED -> BookViewStatus.SERVICE_CANCELED;
+            };
         }
     }
 
@@ -45,8 +60,7 @@ public class BookModel {
         Long discountedPrice,
 
         LocalDateTime deadline,
-        String tags,
-        String status
+        String tags
     ) {
 
         public static ServiceDetail from(ServiceItem item) {
@@ -75,8 +89,7 @@ public class BookModel {
                 item.getPrice().getDiscountedPrice(),
 
                 item.getDeadline(),
-                item.getTag(),
-                item.getStatus().name()
+                item.getTag()
             );
         }
     }

--- a/src/main/java/teamssavice/ssavice/serviceItem/constants/ServiceStatus.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/constants/ServiceStatus.java
@@ -9,7 +9,7 @@ public enum ServiceStatus {
     FULLED("모집 마감"), // (최대 인원 충족) OR (최소 인원 충족 + 모집마감)
     FAILED("모집 실패"), // 최소 인원 미충족 + 모집 마감
     CANCELED("모집 취소"), // 게시자가 삭제
-    INUSE("이용 중"), // 모집 마감된 서비스가 서비스되는 기간 중에 있음
+    IN_USE("이용 중"), // 모집 마감된 서비스가 서비스되는 기간 중에 있음
     COMPLETED("이용 완료"); // 모집 마감된 서비스가 서비스 이용이 종료
 
     private final String description;

--- a/src/main/java/teamssavice/ssavice/serviceItem/constants/ServiceStatus.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/constants/ServiceStatus.java
@@ -4,12 +4,13 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum ServiceStatus {
-    RECRUITING("모집 중"),
-    SUCCEEDED("모집 성공"), // 최소 인원을 충족시켰다는 의미 - 환불이나 취소에서 모집중이랑은 차이가 있음
-    FULLED("모집 마감"), // 이제 더 이상 신청 불가능
-    FAILED("모집 실패"),
-    CANCELED("모집 취소"),
-    COMPLETED("이용 완료"); // 서비스 이용이 종료돼서 리뷰가 가능한 상태
+    RECRUITING("모집 중"), // 최소 인원 미충족 + 모집 마감 전
+    SUCCEEDED("모집 성공"), // 최소 인원 충족 + 모집 마감 전
+    FULLED("모집 마감"), // (최대 인원 충족) OR (최소 인원 충족 + 모집마감)
+    FAILED("모집 실패"), // 최소 인원 미충족 + 모집 마감
+    CANCELED("모집 취소"), // 게시자가 삭제
+    INUSE("이용 중"), // 모집 마감된 서비스가 서비스되는 기간 중에 있음
+    COMPLETED("이용 완료"); // 모집 마감된 서비스가 서비스 이용이 종료
 
     private final String description;
 }

--- a/src/main/java/teamssavice/ssavice/serviceItem/controller/ServiceItemController.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/controller/ServiceItemController.java
@@ -98,10 +98,9 @@ public class ServiceItemController {
     public ResponseEntity<PageResponse<ServiceItemResponse.Summary>> getCompanysServiceItems(
         @PathVariable("company-id") Long companyId,
         @PageableDefault(page = 0, size = 10) Pageable pageable,
-        @RequestParam ServiceItemRequest.ServiceStatusFilter status
+        @RequestParam("on-sale") Boolean onSale
     ) {
-        ServiceItemCommand.RetrieveByCompanyAndStatus command = ServiceItemCommand.RetrieveByCompanyAndStatus.of(companyId, pageable,
-                status.toDomainOrNull());
+        ServiceItemCommand.RetrieveByCompanyAndOnSale command = ServiceItemCommand.RetrieveByCompanyAndOnSale.of(companyId, pageable, onSale);
 
         Page<ServiceItemResponse.Summary> responses = serviceItemService.getServiceByCompanyAndStatus(command)
                 .map(ServiceItemResponse.Summary::from);

--- a/src/main/java/teamssavice/ssavice/serviceItem/controller/dto/ServiceItemRequest.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/controller/dto/ServiceItemRequest.java
@@ -72,7 +72,9 @@ public class ServiceItemRequest {
 
             // 커서 방식 (안드로이드 무한 스크롤과)
             @PositiveOrZero
-            Long lastId
+            Long lastId,
+
+            Boolean onSale
     ) {
         public ServiceItemCommand.Search toCommand(Pageable pageable) {
             return ServiceItemCommand.Search.builder()
@@ -86,6 +88,7 @@ public class ServiceItemRequest {
                     .sortBy(sortBy)
                     .lastId(lastId)
                     .pageable(pageable)
+                    .onSale(Boolean.TRUE.equals(onSale))
                     .build();
         }
     }

--- a/src/main/java/teamssavice/ssavice/serviceItem/controller/dto/ServiceItemRequest.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/controller/dto/ServiceItemRequest.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import org.springframework.data.domain.Pageable;
 import teamssavice.ssavice.address.AddressRequest;
 import teamssavice.ssavice.imageresource.ImageRequest;
-import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.service.dto.ServiceItemCommand;
 
 import java.time.LocalDateTime;
@@ -90,19 +89,6 @@ public class ServiceItemRequest {
                     .pageable(pageable)
                     .onSale(Boolean.TRUE.equals(onSale))
                     .build();
-        }
-    }
-
-    public enum ServiceStatusFilter {
-        ALL,
-        RECRUITING,
-        SUCCESS,
-        FAILED,
-        CANCELED,
-        FINISHED;
-
-        public ServiceStatus toDomainOrNull() {
-            return this == ALL ? null : ServiceStatus.valueOf(this.name());
         }
     }
 }

--- a/src/main/java/teamssavice/ssavice/serviceItem/entity/ServiceItem.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/entity/ServiceItem.java
@@ -62,11 +62,6 @@ public class ServiceItem extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime deadline; // 이벤트 마감 기간
 
-    @Enumerated(EnumType.STRING)
-    @Builder.Default
-    @Column(nullable = false)
-    private ServiceStatus status = ServiceStatus.RECRUITING;
-
     private String category;
 
     private String tag; // 엘라스틱 서치 도입 예정
@@ -109,20 +104,24 @@ public class ServiceItem extends BaseEntity {
         return imageIds.isEmpty();
     }
 
+    public ServiceStatus getStatus() {
+        if(this.isDeleted) return ServiceStatus.CANCELED;
+        if(isInUse()) return ServiceStatus.INUSE;
+        if(isCompleted()) return ServiceStatus.COMPLETED;
+        if(isFull()) return ServiceStatus.FULLED;
+        if (isTimeOver()) {
+            if(!isReachedMinimum()) return ServiceStatus.FAILED;
+            return ServiceStatus.FULLED;
+        }
+        if(isReachedMinimum()) return ServiceStatus.SUCCEEDED;
+        return ServiceStatus.RECRUITING;
+    }
 
     public void participate() {
         if (this.isFull()) {
             throw new ConflictException(ErrorCode.MEMBER_FULL);
         }
         this.currentMember++;
-
-        if (this.status == ServiceStatus.RECRUITING && isReachedMinimum()) {
-            this.status = ServiceStatus.SUCCEEDED;
-        }
-
-        if (isFull()) {
-            this.status = ServiceStatus.FULLED;
-        }
     }
 
     public boolean isReachedMinimum() {
@@ -133,46 +132,37 @@ public class ServiceItem extends BaseEntity {
         return this.currentMember >= this.maximumMember;
     }
 
-    public void finish() {
-        this.status = ServiceStatus.FULLED;
+    // 이용 종료 여부
+    public boolean isTimeOver() {
+        return this.deadline.isBefore(LocalDateTime.now());
+    }
+
+    // 이용중인지 여부
+    public boolean isInUse() {
+        LocalDateTime now = LocalDateTime.now();
+        return isReachedMinimum() && (now.isAfter(startDate) || now.isEqual(startDate)) && now.isBefore(endDate);
+    }
+
+    public boolean isCompleted() {
+        return isReachedMinimum() && LocalDateTime.now().isAfter(endDate);
     }
 
     // 서비스아이템 등록을 위한 검증
-    public void validateAppliable(LocalDateTime now) {
+    public void validateAppliable() {
         // 삭제 여부
-        if (this.isDeleted) {
-            throw new ConflictException(ErrorCode.SERVICE_DELETED);
-        }
+        ServiceStatus status = getStatus();
         // 안되는 상황 구체화
-        switch (this.status) {
+        switch (status) {
             case FAILED -> throw new ConflictException(ErrorCode.SERVICE_RECRUITMENT_FAILED);
             case CANCELED -> throw new ConflictException(ErrorCode.SERVICE_RECRUITMENT_CANCELED);
             case COMPLETED -> throw new ConflictException(ErrorCode.SERVICE_ALREADY_COMPLETED);
             case FULLED -> throw new ConflictException(ErrorCode.MEMBER_FULL);
         }
 
+
         // 마감 기한 확인
-        if (now.isAfter(this.deadline)) {
+        if (LocalDateTime.now().isAfter(this.deadline)) {
             throw new ConflictException(ErrorCode.SERVICE_DEADLINE_EXPIRED);
         }
-
-        if (this.currentMember >= this.maximumMember) {
-            throw new ConflictException(ErrorCode.MEMBER_FULL);
-        }
     }
-
-    // 이용중인지 여부
-    public boolean isInUse(LocalDateTime now) {
-        return (status == ServiceStatus.SUCCEEDED || status == ServiceStatus.FULLED)
-                && (now.isAfter(startDate) || now.isEqual(startDate))
-                && now.isBefore(endDate);
-    }
-
-    // 이용 종료 여부
-    public boolean isTimeOver(LocalDateTime now) {
-        return (status == ServiceStatus.SUCCEEDED || status == ServiceStatus.FULLED)
-                && (now.isAfter(endDate) || now.isEqual(endDate));
-    }
-
-
 }

--- a/src/main/java/teamssavice/ssavice/serviceItem/entity/ServiceItem.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/entity/ServiceItem.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 public class ServiceItem extends BaseEntity {
 
@@ -106,7 +106,7 @@ public class ServiceItem extends BaseEntity {
 
     public ServiceStatus getStatus() {
         if(this.isDeleted) return ServiceStatus.CANCELED;
-        if(isInUse()) return ServiceStatus.INUSE;
+        if(isInUse()) return ServiceStatus.IN_USE;
         if(isCompleted()) return ServiceStatus.COMPLETED;
         if(isFull()) return ServiceStatus.FULLED;
         if (isTimeOver()) {

--- a/src/main/java/teamssavice/ssavice/serviceItem/infrastructure/repository/ServiceItemRepository.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/infrastructure/repository/ServiceItemRepository.java
@@ -3,15 +3,23 @@ package teamssavice.ssavice.serviceItem.infrastructure.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import teamssavice.ssavice.company.entity.Company;
-import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ServiceItemRepository extends JpaRepository<ServiceItem, Long>, ServiceItemRepositoryCustom {
 
     List<ServiceItem> findTop5ByCompanyOrderByDeadlineDesc(Company company);
 
-    Page<ServiceItem> findAllByCompany_IdAndStatus(Long companyId, ServiceStatus status, Pageable pageable);
+    Page<ServiceItem> findAllByCompany_Id(Long companyId, Pageable pageable);
+
+    @Query("SELECT s FROM ServiceItem s " +
+            "WHERE s.company.id = :companyId " +
+            "AND s.isDeleted = false " +
+            "AND s.deadline > :now " +
+            "AND s.currentMember < s.maximumMember")
+    Page<ServiceItem> findAllRecruitingByCompany_Id(Long companyId, LocalDateTime now, Pageable pageable);
 }

--- a/src/main/java/teamssavice/ssavice/serviceItem/infrastructure/repository/ServiceItemRepositoryImpl.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/infrastructure/repository/ServiceItemRepositoryImpl.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 import teamssavice.ssavice.serviceItem.service.dto.ServiceItemCommand;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static teamssavice.ssavice.company.entity.QCompany.company;
@@ -23,8 +25,7 @@ public class ServiceItemRepositoryImpl implements ServiceItemRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<ServiceItem>
-    search(ServiceItemCommand.Search command) {
+    public Slice<ServiceItem> search(ServiceItemCommand.Search command) {
 
         Pageable pageable = command.pageable();
         int pageSize = pageable.getPageSize();
@@ -39,7 +40,8 @@ public class ServiceItemRepositoryImpl implements ServiceItemRepositoryCustom {
                         eqCategory(command.category()),
                         containsQuery(command.query()),
                         goeMinPrice(command.minPrice()),
-                        loeMaxPrice(command.maxPrice())
+                        loeMaxPrice(command.maxPrice()),
+                        applyOnSaleCondition(command.onSale())
                 )
                 .orderBy(getOrderSpecifier(command.sortBy()))
                 .limit(pageSize + 1)
@@ -78,8 +80,8 @@ public class ServiceItemRepositoryImpl implements ServiceItemRepositoryCustom {
     }
 
     private OrderSpecifier<?>[] getOrderSpecifier(Integer sortBy) {
-        // 기본값: ID 내림차 순 (최신순)
-        OrderSpecifier[] defaultSort = { serviceItem.id.desc() };
+        // 기본값: createdAt 내림차순 (최신순)
+        OrderSpecifier[] defaultSort = { serviceItem.createdAt.desc() };
 
         if (sortBy == null) {
             return defaultSort;
@@ -95,5 +97,14 @@ public class ServiceItemRepositoryImpl implements ServiceItemRepositoryCustom {
             default: // 인기순 하고 마감임박순은 아직 기준이 안정해져서 우선 최신순
                 return defaultSort;
         }
+    }
+
+    private BooleanExpression applyOnSaleCondition(boolean onSale) {
+        if(!onSale) return null;
+        LocalDateTime now = LocalDateTime.now();
+
+        return serviceItem.isDeleted.isFalse()
+                .and(serviceItem.deadline.gt(now))
+                .and(serviceItem.currentMember.lt(serviceItem.maximumMember));
     }
 }

--- a/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemReadService.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemReadService.java
@@ -9,11 +9,11 @@ import org.springframework.transaction.annotation.Transactional;
 import teamssavice.ssavice.company.entity.Company;
 import teamssavice.ssavice.global.constants.ErrorCode;
 import teamssavice.ssavice.global.exception.EntityNotFoundException;
-import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 import teamssavice.ssavice.serviceItem.infrastructure.repository.ServiceItemRepository;
 import teamssavice.ssavice.serviceItem.service.dto.ServiceItemCommand;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -40,7 +40,12 @@ public class ServiceItemReadService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ServiceItem> findAllByCompanyAndStatus(Long companyId, ServiceStatus status, Pageable pageable) {
-        return serviceItemRepository.findAllByCompany_IdAndStatus(companyId, status, pageable);
+    public Page<ServiceItem> findAllByCompany_Id(Long companyId, Pageable pageable) {
+        return serviceItemRepository.findAllByCompany_Id(companyId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ServiceItem> findAllRecruitingByCompany_Id(Long companyId, Pageable pageable) {
+        return serviceItemRepository.findAllRecruitingByCompany_Id(companyId, LocalDateTime.now(), pageable);
     }
 }

--- a/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemService.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemService.java
@@ -29,7 +29,6 @@ import teamssavice.ssavice.serviceItem.service.dto.ServiceItemModel;
 import teamssavice.ssavice.user.entity.Users;
 import teamssavice.ssavice.user.service.UserReadService;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -103,22 +102,24 @@ public class ServiceItemService {
 
         Book book = bookWriteService.save(user, serviceItem, BookStatus.RESERVED);
 
-        return BookModel.Apply.of(
-                book.getId()
-        );
+        return BookModel.Apply.of(book.getId());
     }
 
     private void validateApply(Users user, ServiceItem serviceItem) {
 
-        serviceItem.validateAppliable(LocalDateTime.now());
+        serviceItem.validateAppliable();
 
         if (bookReadService.existsByUserAndServiceItem(user, serviceItem)) {
             throw new ConflictException(ErrorCode.ALREADY_APPLIED);
         }
     }
 
-    public Page<ServiceItemModel.Summary> getServiceByCompanyAndStatus(ServiceItemCommand.RetrieveByCompanyAndStatus command) {
-        Page<ServiceItem> serviceItems = serviceItemReadService.findAllByCompanyAndStatus(command.companyId(), command.status(), command.pageable());
+    public Page<ServiceItemModel.Summary> getServiceByCompanyAndStatus(ServiceItemCommand.RetrieveByCompanyAndOnSale command) {
+        if (command.onSale()) {
+            Page<ServiceItem> serviceItems = serviceItemReadService.findAllRecruitingByCompany_Id(command.companyId(), command.pageable());
+            return serviceItems.map(ServiceItemModel.Summary::from);
+        }
+        Page<ServiceItem> serviceItems = serviceItemReadService.findAllByCompany_Id(command.companyId(), command.pageable());
         return serviceItems.map(ServiceItemModel.Summary::from);
     }
 }

--- a/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemService.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemService.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamssavice.ssavice.address.AddressCommand;
-import teamssavice.ssavice.book.constants.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.service.BookReadService;
 import teamssavice.ssavice.book.service.BookWriteService;
@@ -100,7 +99,7 @@ public class ServiceItemService {
 
         serviceItem.participate();
 
-        Book book = bookWriteService.save(user, serviceItem, BookStatus.RESERVED);
+        Book book = bookWriteService.apply(user, serviceItem);
 
         return BookModel.Apply.of(book.getId());
     }

--- a/src/main/java/teamssavice/ssavice/serviceItem/service/dto/ServiceItemCommand.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/service/dto/ServiceItemCommand.java
@@ -2,7 +2,6 @@ package teamssavice.ssavice.serviceItem.service.dto;
 
 import lombok.Builder;
 import org.springframework.data.domain.Pageable;
-import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -45,21 +44,22 @@ public class ServiceItemCommand {
         Long maxPrice,
         Integer sortBy,
         Long lastId,      // 커서 ID
-        Pageable pageable
+        Pageable pageable,
+        boolean onSale
     ) {
     }
 
     @Builder
-    public record RetrieveByCompanyAndStatus(
+    public record RetrieveByCompanyAndOnSale(
         Long companyId,
         Pageable pageable,
-        ServiceStatus status
+        boolean onSale
     ) {
-        public static RetrieveByCompanyAndStatus of(Long companyId, Pageable pageable, ServiceStatus status) {
-            return RetrieveByCompanyAndStatus.builder()
+        public static RetrieveByCompanyAndOnSale of(Long companyId, Pageable pageable, Boolean onSale) {
+            return RetrieveByCompanyAndOnSale.builder()
                     .companyId(companyId)
                     .pageable(pageable)
-                    .status(status)
+                    .onSale(Boolean.TRUE.equals(onSale))
                     .build();
         }
     }

--- a/src/main/java/teamssavice/ssavice/serviceItem/service/dto/ServiceItemModel.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/service/dto/ServiceItemModel.java
@@ -120,8 +120,8 @@ public class ServiceItemModel {
             LocalDateTime createdAt,
             String category,
             String tag,
-            Long currentMember,
 
+            Long currentMember,
             Long minimumMember,
             Long maximumMember,
 

--- a/src/test/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryImplTest.java
+++ b/src/test/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryImplTest.java
@@ -1,0 +1,144 @@
+package teamssavice.ssavice.book.infrastructure.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.annotation.DirtiesContext;
+import teamssavice.ssavice.book.constants.BookStatusFilter;
+import teamssavice.ssavice.book.constants.BookViewStatus;
+import teamssavice.ssavice.book.entity.Book;
+import teamssavice.ssavice.book.entity.BookStatus;
+import teamssavice.ssavice.book.service.dto.BookModel;
+import teamssavice.ssavice.company.entity.Company;
+import teamssavice.ssavice.fixture.*;
+import teamssavice.ssavice.global.config.QueryDSLConfig;
+import teamssavice.ssavice.serviceItem.entity.ServiceItem;
+import teamssavice.ssavice.user.entity.Users;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QueryDSLConfig.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+
+class BookRepositoryImplTest {
+    @Autowired
+    private BookRepository bookRepository;
+    @Autowired
+    private TestEntityManager tem;
+
+    private Users user;
+
+    @BeforeEach
+    void setUp() {
+        user = UserFixture.user();
+        Company company = CompanyFixture.company(user, AddressFixture.address());
+        ServiceItem recruitingService = ServiceItemFixture.recruiting(company);
+        ServiceItem succeededService = ServiceItemFixture.succeeded(company);
+        ServiceItem fulledService = ServiceItemFixture.fulled(company);
+        ServiceItem inUseService = ServiceItemFixture.inUse(company);
+        ServiceItem completeService = ServiceItemFixture.completed(company);
+        ServiceItem failService = ServiceItemFixture.failed(company);
+        ServiceItem canceledService = ServiceItemFixture.canceled(company);
+
+        tem.persist(user);
+        tem.persist(company);
+        tem.persist(recruitingService);
+        tem.persist(succeededService);
+        tem.persist(fulledService);
+        tem.persist(inUseService);
+        tem.persist(completeService);
+        tem.persist(failService);
+        tem.persist(canceledService);
+
+        Book recruitingBook = BookFixture.book(user, recruitingService, BookStatus.RESERVED);
+        Book succeededBook = BookFixture.book(user, succeededService, BookStatus.RESERVED);
+        Book fulledBook = BookFixture.book(user, fulledService, BookStatus.RESERVED);
+        Book inUseBook = BookFixture.book(user, inUseService, BookStatus.RESERVED);
+        Book completeBook = BookFixture.book(user, completeService, BookStatus.RESERVED);
+        Book failBook = BookFixture.book(user, failService, BookStatus.RESERVED);
+        Book userCancelBook = BookFixture.book(user, canceledService, BookStatus.RESERVED);
+        Book serviceCancelBook = BookFixture.book(user, recruitingService, BookStatus.CANCELED);
+
+        tem.persist(recruitingBook);
+        tem.persist(succeededBook);
+        tem.persist(fulledBook);
+        tem.persist(inUseBook);
+        tem.persist(completeBook);
+        tem.persist(failBook);
+        tem.persist(userCancelBook);
+        tem.persist(serviceCancelBook);
+    }
+
+    @Test
+    @DisplayName("BookStatusFilter가 ALL일 때 findAllByUserIdAndStatus() 테스트")
+    void findAllByUserIdAndStatusTestWhenAll() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when
+        Page<Book> actuals = bookRepository.findAllByUserIdAndStatus(user.getId(), BookStatusFilter.ALL, pageable);
+        Page<BookModel.Info> actualModels = actuals.map(BookModel.Info::from);
+
+        // then
+        assertThat(actualModels.getTotalElements()).isEqualTo(8);
+    }
+
+    @Test
+    @DisplayName("BookStatusFilter가 RECRUITING일 때 findAllByUserIdAndStatus() 테스트")
+    void findAllByUserIdAndStatusTestWhenRecruiting() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when
+        Page<Book> actuals = bookRepository.findAllByUserIdAndStatus(user.getId(), BookStatusFilter.RECRUITING, pageable);
+        Page<BookModel.Info> actualModels = actuals.map(BookModel.Info::from);
+
+        // then
+        assertThat(actualModels.getTotalElements()).isEqualTo(2);
+        for (BookModel.Info model : actualModels) {
+            assertThat(model.bookStatus()).isIn(BookViewStatus.RECRUITING, BookViewStatus.SUCCEEDED);
+        }
+    }
+
+    @Test
+    @DisplayName("BookStatusFilter가 COMPLETE일 때 findAllByUserIdAndStatus() 테스트")
+    void findAllByUserIdAndStatusTestWhenComplete() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when
+        Page<Book> actuals = bookRepository.findAllByUserIdAndStatus(user.getId(), BookStatusFilter.COMPLETED, pageable);
+        Page<BookModel.Info> actualModels = actuals.map(BookModel.Info::from);
+
+        // then
+        assertThat(actualModels.getTotalElements()).isEqualTo(3);
+        for (BookModel.Info model : actualModels) {
+            assertThat(model.bookStatus()).isIn(BookViewStatus.FULLED, BookViewStatus.IN_USE, BookViewStatus.COMPLETED);
+        }
+    }
+
+    @Test
+    @DisplayName("BookStatusFilter가 CANCELED일 때 findAllByUserIdAndStatus() 테스트")
+    void findAllByUserIdAndStatusTestWhenCanceled() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when
+        Page<Book> actuals = bookRepository.findAllByUserIdAndStatus(user.getId(), BookStatusFilter.CANCELED, pageable);
+        Page<BookModel.Info> actualModels = actuals.map(BookModel.Info::from);
+
+        // then
+        assertThat(actualModels.getTotalElements()).isEqualTo(3);
+        for (BookModel.Info model : actualModels) {
+            assertThat(model.bookStatus()).isIn(BookViewStatus.FAILED, BookViewStatus.USER_CANCELED, BookViewStatus.SERVICE_CANCELED);
+        }
+    }
+}

--- a/src/test/java/teamssavice/ssavice/book/service/BookServiceTest.java
+++ b/src/test/java/teamssavice/ssavice/book/service/BookServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import teamssavice.ssavice.book.constants.BookStatus;
+import teamssavice.ssavice.book.entity.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.service.dto.BookModel;
 import teamssavice.ssavice.fixture.BookFixture;
@@ -37,8 +37,8 @@ class BookServiceTest {
     void setUp() {
         Users user = UserFixture.user();
         for (int i = 0; i < 5; i++) {
-            books.add(BookFixture.book(user, ServiceItemFixture.fulled(), BookStatus.RESERVED));
-            books.add(BookFixture.book(user, ServiceItemFixture.recruiting(), BookStatus.RESERVED));
+            books.add(BookFixture.book(user, ServiceItemFixture.fulled(null), BookStatus.RESERVED));
+            books.add(BookFixture.book(user, ServiceItemFixture.recruiting(null), BookStatus.RESERVED));
         }
     }
 

--- a/src/test/java/teamssavice/ssavice/book/service/BookServiceTest.java
+++ b/src/test/java/teamssavice/ssavice/book/service/BookServiceTest.java
@@ -1,5 +1,6 @@
 package teamssavice.ssavice.book.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -7,8 +8,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import teamssavice.ssavice.book.constants.BookStatus;
+import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.service.dto.BookModel;
-import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
+import teamssavice.ssavice.fixture.BookFixture;
+import teamssavice.ssavice.fixture.ServiceItemFixture;
+import teamssavice.ssavice.fixture.UserFixture;
+import teamssavice.ssavice.user.entity.Users;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -23,6 +31,17 @@ class BookServiceTest {
     @Mock
     private BookReadService bookReadService;
 
+    private final List<Book> books = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        Users user = UserFixture.user();
+        for (int i = 0; i < 5; i++) {
+            books.add(BookFixture.book(user, ServiceItemFixture.fulled(), BookStatus.RESERVED));
+            books.add(BookFixture.book(user, ServiceItemFixture.recruiting(), BookStatus.RESERVED));
+        }
+    }
+
     @Test
     @DisplayName("사용자의 예약 요약 정보 조회 시, 각 상태별 카운트가 정확히 합산되어 반환된다")
     void getBookSummary_test() {
@@ -31,21 +50,11 @@ class BookServiceTest {
 
         // Mock 데이터 설정
         Long recruitingCount = 5L; // 모집 중
-        Long succeededCount = 3L;  // 모집 성공
-        Long closedCount = 2L;     // 모집 마감
+        Long completedCount = 5L;  // 모집 성공 및 마감
 
         // 각 상태별로 호출될 때 반환할 값 지정
-        given(bookReadService.countByUserIdAndBookStatusAndServiceStatus(
-                userId, BookStatus.RESERVED, ServiceStatus.RECRUITING))
-                .willReturn(recruitingCount);
-
-        given(bookReadService.countByUserIdAndBookStatusAndServiceStatus(
-                userId, BookStatus.RESERVED, ServiceStatus.SUCCEEDED))
-                .willReturn(succeededCount);
-
-        given(bookReadService.countByUserIdAndBookStatusAndServiceStatus(
-                userId, BookStatus.RESERVED, ServiceStatus.FULLED))
-                .willReturn(closedCount);
+        given(bookReadService.findByUserIdAndBookStatus(userId, BookStatus.RESERVED))
+                .willReturn(books);
 
         // when
         BookModel.BookSummary result = bookService.getBookSummary(userId);
@@ -59,11 +68,7 @@ class BookServiceTest {
         assertThat(result.completed()).isEqualTo(5L);
 
         // 2. 각 메서드가 정확히 호출되었는지 검증
-        verify(bookReadService).countByUserIdAndBookStatusAndServiceStatus(
-                userId, BookStatus.RESERVED, ServiceStatus.RECRUITING);
-        verify(bookReadService).countByUserIdAndBookStatusAndServiceStatus(
-                userId, BookStatus.RESERVED, ServiceStatus.SUCCEEDED);
-        verify(bookReadService).countByUserIdAndBookStatusAndServiceStatus(
-                userId, BookStatus.RESERVED, ServiceStatus.FULLED);
+        verify(bookReadService).findByUserIdAndBookStatus(
+                userId, BookStatus.RESERVED);
     }
 }

--- a/src/test/java/teamssavice/ssavice/fixture/BookFixture.java
+++ b/src/test/java/teamssavice/ssavice/fixture/BookFixture.java
@@ -1,6 +1,6 @@
 package teamssavice.ssavice.fixture;
 
-import teamssavice.ssavice.book.constants.BookStatus;
+import teamssavice.ssavice.book.entity.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 import teamssavice.ssavice.user.entity.Users;

--- a/src/test/java/teamssavice/ssavice/fixture/ServiceItemFixture.java
+++ b/src/test/java/teamssavice/ssavice/fixture/ServiceItemFixture.java
@@ -2,7 +2,6 @@ package teamssavice.ssavice.fixture;
 
 import teamssavice.ssavice.address.Address;
 import teamssavice.ssavice.company.entity.Company;
-import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.Price;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 
@@ -27,7 +26,7 @@ public class ServiceItemFixture {
                 .build();
     }
 
-    public static ServiceItem setCompanyAndStatus(Company company, ServiceStatus status) {
+    public static ServiceItem setCompany(Company company) {
         return ServiceItem.builder()
                 .title("title")
                 .description("this is desc")
@@ -50,7 +49,28 @@ public class ServiceItemFixture {
                         .address("address")
                         .detailAddress("detail")
                         .build())
-                .status(status)
+                .build();
+    }
+
+    public static ServiceItem fulled() {
+        return ServiceItem.builder()
+                .currentMember(20L)
+                .minimumMember(10L)
+                .maximumMember(20L)
+                .startDate(LocalDateTime.now().plusDays(10))
+                .endDate(LocalDateTime.now().plusDays(30))
+                .deadline(LocalDateTime.now().plusDays(5))
+                .build();
+    }
+
+    public static ServiceItem recruiting() {
+        return ServiceItem.builder()
+                .currentMember(5L)
+                .minimumMember(10L)
+                .maximumMember(20L)
+                .startDate(LocalDateTime.now().plusDays(10))
+                .endDate(LocalDateTime.now().plusDays(30))
+                .deadline(LocalDateTime.now().plusDays(5))
                 .build();
     }
 }

--- a/src/test/java/teamssavice/ssavice/fixture/ServiceItemFixture.java
+++ b/src/test/java/teamssavice/ssavice/fixture/ServiceItemFixture.java
@@ -52,25 +52,78 @@ public class ServiceItemFixture {
                 .build();
     }
 
-    public static ServiceItem fulled() {
+    public static ServiceItem base(Company company) {
         return ServiceItem.builder()
-                .currentMember(20L)
-                .minimumMember(10L)
-                .maximumMember(20L)
-                .startDate(LocalDateTime.now().plusDays(10))
-                .endDate(LocalDateTime.now().plusDays(30))
-                .deadline(LocalDateTime.now().plusDays(5))
-                .build();
-    }
-
-    public static ServiceItem recruiting() {
-        return ServiceItem.builder()
+                .title("title")
+                .description("this is desc")
+                .price(Price.of(1000L, 10))
                 .currentMember(5L)
                 .minimumMember(10L)
                 .maximumMember(20L)
                 .startDate(LocalDateTime.now().plusDays(10))
                 .endDate(LocalDateTime.now().plusDays(30))
                 .deadline(LocalDateTime.now().plusDays(5))
+                .category("category")
+                .company(company)
+                .address(Address.builder()
+                        .gugun("gugun")
+                        .gugunCode("gugunCode")
+                        .region("region")
+                        .regionCode("regionCode")
+                        .latitude(BigDecimal.valueOf(33.333))
+                        .longitude(BigDecimal.valueOf(33.333))
+                        .postCode("postCode")
+                        .address("address")
+                        .detailAddress("detail")
+                        .build())
+                .build();
+    }
+
+    public static ServiceItem recruiting(Company company) {
+        return base(company);
+    }
+
+    public static ServiceItem succeeded(Company company) {
+        return base(company).toBuilder()
+                .currentMember(11L)
+                .minimumMember(10L)
+                .maximumMember(20L)
+                .build();
+    }
+
+    public static ServiceItem fulled(Company company) {
+        return base(company).toBuilder()
+                .currentMember(20L)
+                .minimumMember(10L)
+                .maximumMember(20L)
+                .build();
+    }
+
+    public static ServiceItem inUse(Company company) {
+        return fulled(company).toBuilder()
+                .deadline(LocalDateTime.now().minusDays(20))
+                .startDate(LocalDateTime.now().minusDays(5))
+                .endDate(LocalDateTime.now().plusDays(5))
+                .build();
+    }
+
+    public static ServiceItem completed(Company company) {
+        return fulled(company).toBuilder()
+                .deadline(LocalDateTime.now().minusDays(20))
+                .startDate(LocalDateTime.now().minusDays(5))
+                .endDate(LocalDateTime.now().minusDays(1))
+                .build();
+    }
+
+    public static ServiceItem failed(Company company) {
+        return base(company).toBuilder()
+                .deadline(LocalDateTime.now().minusDays(1))
+                .build();
+    }
+
+    public static ServiceItem canceled(Company company) {
+        return base(company).toBuilder()
+                .isDeleted(true)
                 .build();
     }
 }

--- a/src/test/java/teamssavice/ssavice/serviceItem/entity/ServiceItemTest.java
+++ b/src/test/java/teamssavice/ssavice/serviceItem/entity/ServiceItemTest.java
@@ -17,15 +17,13 @@ public class ServiceItemTest {
     @DisplayName("최대 인원에 도달하도록 참여하면 서비스 상태가 FINISHED로 자동 변경된다")
     void entity_logic_test() {
         // Given: 최대 인원 10명 현재 9명
-        ServiceItem item = ServiceItemFixture.custom("테스트", LocalDateTime.now(), null, null);
+        ServiceItem item = ServiceItemFixture.custom("테스트", LocalDateTime.now().plusDays(5), null, null);
         ReflectionTestUtils.setField(item, "minimumMember", 10L);
         ReflectionTestUtils.setField(item, "maximumMember", 11L);
         ReflectionTestUtils.setField(item, "currentMember", 9L);
-        ReflectionTestUtils.setField(item, "status", ServiceStatus.RECRUITING);
 
         // When 한명 참여시
         item.participate();
-
         // Then 10명이 되면서 서비스 상태가 변하는지
         assertAll(
                 () -> assertThat(item.getCurrentMember()).isEqualTo(10L),

--- a/src/test/java/teamssavice/ssavice/serviceItem/infrastructure/repository/ServiceItemRepositoryTest.java
+++ b/src/test/java/teamssavice/ssavice/serviceItem/infrastructure/repository/ServiceItemRepositoryTest.java
@@ -18,7 +18,6 @@ import teamssavice.ssavice.fixture.CompanyFixture;
 import teamssavice.ssavice.fixture.ServiceItemFixture;
 import teamssavice.ssavice.fixture.UserFixture;
 import teamssavice.ssavice.global.config.QueryDSLConfig;
-import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 import teamssavice.ssavice.user.entity.Users;
 import teamssavice.ssavice.user.infrastructure.repository.UserRepository;
@@ -75,15 +74,14 @@ class ServiceItemRepositoryTest {
     }
 
     @Test
-    @DisplayName("회사Id와 status로 service 검색 테스트")
+    @DisplayName("회사Id로 service 검색 테스트")
     void findAllByCompanyIdAndStatusTest() {
         // given
         userRepository.save(this.user);
         Company company = companyRepository.save(this.company);
-        ServiceStatus status = ServiceStatus.SUCCEEDED;
         List<ServiceItem> serviceItems = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
-            serviceItems.add(ServiceItemFixture.setCompanyAndStatus(company, status));
+            serviceItems.add(ServiceItemFixture.setCompany(company));
         }
         serviceItemRepository.saveAll(serviceItems);
         Pageable pageable = PageRequest.of(0, 10);
@@ -91,12 +89,11 @@ class ServiceItemRepositoryTest {
         em.clear();
 
         // when
-        Page<ServiceItem> actuals = serviceItemRepository.findAllByCompany_IdAndStatus(company.getId(), status, pageable);
+        Page<ServiceItem> actuals = serviceItemRepository.findAllByCompany_Id(company.getId(), pageable);
 
         // then
         assertAll(
-                () -> assertThat(actuals.getContent()).hasSize(5),
-                () -> assertThat(actuals.getContent().get(0).getStatus()).isEqualTo(status)
+                () -> assertThat(actuals.getContent()).hasSize(5)
         );
     }
 }

--- a/src/test/java/teamssavice/ssavice/serviceItem/service/ServiceItemServiceTest.java
+++ b/src/test/java/teamssavice/ssavice/serviceItem/service/ServiceItemServiceTest.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -86,7 +85,6 @@ public class ServiceItemServiceTest {
         ReflectionTestUtils.setField(serviceItem, "minimumMember", 10L);
         ReflectionTestUtils.setField(serviceItem, "maximumMember", 20L);
         ReflectionTestUtils.setField(serviceItem, "currentMember", 19L);
-        ReflectionTestUtils.setField(serviceItem, "status", ServiceStatus.SUCCEEDED); // 이미 최소인원은 넘은 상태 가정
 
         Users user = UserFixture.user();
 

--- a/src/test/java/teamssavice/ssavice/serviceItem/service/ServiceItemServiceTest.java
+++ b/src/test/java/teamssavice/ssavice/serviceItem/service/ServiceItemServiceTest.java
@@ -7,8 +7,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import teamssavice.ssavice.book.constants.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
+import teamssavice.ssavice.book.entity.BookStatus;
 import teamssavice.ssavice.book.service.BookReadService;
 import teamssavice.ssavice.book.service.BookWriteService;
 import teamssavice.ssavice.book.service.dto.BookModel;
@@ -24,7 +24,6 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -59,14 +58,14 @@ public class ServiceItemServiceTest {
         given(bookReadService.existsByUserAndServiceItem(user, serviceItem)).willReturn(false);
 
         Book mockBook = BookFixture.book(user, serviceItem, BookStatus.RESERVED);
-        given(bookWriteService.save(any(), any(), eq(BookStatus.RESERVED))).willReturn(mockBook);
+        given(bookWriteService.apply(any(), any())).willReturn(mockBook);
 
         // when
         BookModel.Apply result = serviceItemService.apply(userId, serviceId);
 
         // then
 
-        verify(bookWriteService).save(any(), any(), eq(BookStatus.RESERVED));
+        verify(bookWriteService).apply(any(), any());
 
         assertThat(serviceItem.getStatus()).isEqualTo(ServiceStatus.SUCCEEDED);
 
@@ -94,14 +93,14 @@ public class ServiceItemServiceTest {
 
         // 저장될 때는 역시나 RESERVED 상태여야 함
         Book mockBook = BookFixture.book(user, serviceItem, BookStatus.RESERVED);
-        given(bookWriteService.save(any(), any(), eq(BookStatus.RESERVED))).willReturn(mockBook);
+        given(bookWriteService.apply(any(), any())).willReturn(mockBook);
 
         // when
         BookModel.Apply result = serviceItemService.apply(userId, serviceId);
 
         // then
         // 1. Book 저장 호출 검증
-        verify(bookWriteService).save(any(), any(), eq(BookStatus.RESERVED));
+        verify(bookWriteService).apply(any(), any());
 
         // 2. 서비스 아이템의 상태가 FULLED 로 변했는지 검증
         assertThat(serviceItem.getStatus()).isEqualTo(ServiceStatus.FULLED);


### PR DESCRIPTION
## 🔎 작업 내용
* 서비스 검색 API를 최신순으로 변경
* 서비스 검색 API에서 현재 모집중인 서비스만 보이도록 하는 기능 추가
* BookStatus를 3단계로 분리
  * BookStatusFilter: 사용자의 입력부터 db 질의 전까지 사용
  * BookStatus: db에 저장되는 book의 상태
  * BookViewStatus: bookstatus와 ServiceStatus를 조합하여 사용자에게 반환하는 상태
* 사용중인 서비스 내역 반환 API를 BookStatusFilter를 기반으로 조회하도록 변경

## 이미지 첨부

<img width="590" height="166" alt="image" src="https://github.com/user-attachments/assets/30a8fc6a-00e1-4022-9b20-172d515101e7" />
<img width="444" height="304" alt="image" src="https://github.com/user-attachments/assets/017480be-7b18-4ceb-ac53-086b5af4d222" />
<img width="905" height="354" alt="image" src="https://github.com/user-attachments/assets/db7d581b-a3a7-4b42-86fe-0a221bbd90da" />

## To Reviewers 📢
<!-- 리뷰어에게 질문할 사항이나 추가 설명, 요청이 필요한 부분을 여기에 적어주세요. -->

## 체크 리스트
- [x] 테스트를 작성했습니다.
- [x] 테스트를 통과했습니다.
- [x] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #78 
