### PR TITLE
Week6/issue#88 ServiceStatus 복구

### DIFF
--- a/src/main/java/teamssavice/ssavice/book/constants/BookStatusFilter.java
+++ b/src/main/java/teamssavice/ssavice/book/constants/BookStatusFilter.java
@@ -3,7 +3,8 @@ package teamssavice.ssavice.book.constants;
 public enum BookStatusFilter {
     // 전체
     ALL,
-    RECRUITING, // 모집중: RECRUITING, SUCCEEDED
-    COMPLETED,  // 모집완료: FULLED, IN_USE, COMPLETED
+    RECRUITING, // 모집중: RECRUITING
+    SUCCEEDED,  // 모집완료 SUCCEEDED, FULLED, IN_USE
+    COMPLETED,  // 이용완료: COMPLETED
     CANCELED    // 취소: FAILED, CANCELED
 }

--- a/src/main/java/teamssavice/ssavice/book/controller/BookController.java
+++ b/src/main/java/teamssavice/ssavice/book/controller/BookController.java
@@ -22,14 +22,14 @@ import teamssavice.ssavice.global.dto.PageResponse;
 
 
 @RestController
-@RequestMapping("/api/user")
+@RequestMapping("/api")
 @RequiredArgsConstructor
-@RequireRole(Role.USER)
 public class BookController {
 
     private final BookService bookService;
 
-    @GetMapping("/book")
+    @GetMapping("/user/book")
+    @RequireRole(Role.USER)
     public ResponseEntity<PageResponse<BookResponse.Info>> getMyBooksByStatus(
         @CurrentId Long userId,
         @PageableDefault(size = 10) Pageable pageable,
@@ -44,12 +44,37 @@ public class BookController {
         return ResponseEntity.ok(PageResponse.from(reponsePage));
     }
 
-
-    @GetMapping("/book/summary")
+    @GetMapping("/user/book/summary")
+    @RequireRole(Role.USER)
     public ResponseEntity<BookResponse.BookSummary> getBookSummary(
         @CurrentId Long userId
     ) {
         BookModel.BookSummary model = bookService.getBookSummary(userId);
+
+        return ResponseEntity.ok(BookResponse.BookSummary.from(model));
+    }
+
+    @GetMapping("/company/book")
+    @RequireRole(Role.COMPANY)
+    public ResponseEntity<PageResponse<BookResponse.Info>> getMyCompanysBooksByStatus(
+        @CurrentId Long companyId,
+        @PageableDefault(size = 10) Pageable pageable,
+        @RequestParam BookStatusFilter status
+    ) {
+        BookCommand.RetrieveByStatus command = BookCommand.RetrieveByStatus.of(companyId, pageable, status);
+
+        Page<BookModel.Info> models = bookService.getMyCompanysBooksByStatus(command);
+        Page<BookResponse.Info> reponsePage = models.map(BookResponse.Info::from);
+
+        return ResponseEntity.ok(PageResponse.from(reponsePage));
+    }
+
+    @GetMapping("/company/book/summary")
+    @RequireRole(Role.COMPANY)
+    public ResponseEntity<BookResponse.BookSummary> getCompanyBookSummary(
+        @CurrentId Long companyId
+    ) {
+        BookModel.BookSummary model = bookService.getCompanysBookSummary(companyId);
 
         return ResponseEntity.ok(BookResponse.BookSummary.from(model));
     }

--- a/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
+++ b/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
@@ -36,4 +36,20 @@ public interface BookRepository extends JpaRepository<Book, Long>, BookRepositor
     List<Book> findAllByServiceItemIdAndBookStatus(Long serviceItemId, BookStatus bookStatus);
 
     Optional<Book> findFirstByUserIdAndServiceItemIdOrderByCreatedAtDesc(Long userId, Long serviceItemId);
+
+    @Query("SELECT COUNT(b) FROM Book b " +
+            "JOIN b.serviceItem s " +
+            "WHERE s.company.id = :companyId " +
+            "AND b.bookStatus = :bookStatus " +
+            "AND s.status = :recruiting " +
+            "AND s.deadline > :now")
+    Long countRecruitingBooksByCompanyId(Long companyId, BookStatus bookStatus, ServiceStatus recruiting, LocalDateTime now);
+
+    @Query("SELECT COUNT(b) FROM Book b " +
+            "JOIN b.serviceItem s " +
+            "WHERE s.company.id = :companyId " +
+            "AND b.bookStatus = :bookStatus " +
+            "AND s.status = :succeeded " +
+            "AND s.endDate > :now")
+    Long countSucceededBooksByCompanyId(Long companyId, BookStatus bookStatus, ServiceStatus succeeded, LocalDateTime now);
 }

--- a/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
+++ b/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepository.java
@@ -2,12 +2,12 @@ package teamssavice.ssavice.book.infrastructure.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.entity.BookStatus;
-import teamssavice.ssavice.serviceItem.entity.ServiceItem;
+import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,17 +17,23 @@ public interface BookRepository extends JpaRepository<Book, Long>, BookRepositor
 
     boolean existsByUserIdAndServiceItemIdAndBookStatusNot(Long userId, Long serviceItemId, BookStatus bookStatus);
 
-    @Query("SELECT b FROM Book b " +
-            "JOIN b.serviceItem s " + // 페치 조인이 아닌 일반 조인
+    @Query("SELECT COUNT(b) FROM Book b " +
+            "JOIN b.serviceItem s " +
             "WHERE b.user.id = :userId " +
-            "AND b.bookStatus = :bookStatus")
-    List<Book> findByUserIdAndBookStatus(
-            @Param("userId") Long userId,
-            @Param("bookStatus") BookStatus bookStatus
-    );
+            "AND b.bookStatus = :bookStatus " +
+            "AND s.status = :recruiting " +
+            "AND s.deadline > :now")
+    Long countRecruitingBooksByUserId(Long userId, BookStatus bookStatus, ServiceStatus recruiting, LocalDateTime now);
+
+    @Query("SELECT COUNT(b) FROM Book b " +
+            "JOIN b.serviceItem s " +
+            "WHERE b.user.id = :userId " +
+            "AND b.bookStatus = :bookStatus " +
+            "AND s.status = :succeeded " +
+            "AND s.endDate > :now")
+    Long countSucceededBooksByUserId(Long userId, BookStatus bookStatus, ServiceStatus succeeded, LocalDateTime now);
 
     List<Book> findAllByServiceItemIdAndBookStatus(Long serviceItemId, BookStatus bookStatus);
 
     Optional<Book> findFirstByUserIdAndServiceItemIdOrderByCreatedAtDesc(Long userId, Long serviceItemId);
-
 }

--- a/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryCustom.java
+++ b/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryCustom.java
@@ -7,4 +7,6 @@ import teamssavice.ssavice.book.entity.Book;
 
 public interface BookRepositoryCustom {
     Page<Book> findAllByUserIdAndStatus(Long userId, BookStatusFilter status, Pageable pageable);
+
+    Page<Book> findAllByCompanyIdAndStatus(Long company, BookStatusFilter status, Pageable pageable);
 }

--- a/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryImpl.java
+++ b/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import teamssavice.ssavice.book.constants.BookStatusFilter;
 import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.entity.BookStatus;
+import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -61,27 +62,24 @@ public class BookRepositoryImpl implements BookRepositoryCustom {
         }
 
         return switch (status) {
-            case RECRUITING -> serviceItem.isDeleted.isFalse()
-                    .and(book.bookStatus.eq(BookStatus.RESERVED))
-                    .and(serviceItem.currentMember.lt(serviceItem.maximumMember))
+            case RECRUITING -> book.bookStatus.eq(BookStatus.RESERVED)
+                    .and(serviceItem.status.eq(ServiceStatus.RECRUITING))
                     .and(serviceItem.deadline.gt(now));
 
-            case CANCELED -> serviceItem.isDeleted.isTrue()
-                    .or(book.bookStatus.eq(BookStatus.CANCELED))
+            case CANCELED -> book.bookStatus.eq(BookStatus.CANCELED)
+                    .or(serviceItem.status.eq(ServiceStatus.CANCELED))
                     .or(
-                        serviceItem.deadline.lt(now)
-                            .and(serviceItem.currentMember.lt(serviceItem.minimumMember))
+                        serviceItem.status.eq(ServiceStatus.RECRUITING)
+                        .and(serviceItem.deadline.loe(now))
                     );
 
-            case COMPLETED -> serviceItem.isDeleted.isFalse()
-                    .and(book.bookStatus.eq(BookStatus.RESERVED))
-                    .and(
-                        serviceItem.currentMember.goe(serviceItem.maximumMember)
-                            .or(serviceItem.currentMember.goe(serviceItem.minimumMember)
-                                .and(serviceItem.deadline.lt(now))
-                            )
-                    );
+            case SUCCEEDED -> book.bookStatus.eq(BookStatus.RESERVED)
+                    .and(serviceItem.status.eq(ServiceStatus.SUCCEEDED))
+                    .and(serviceItem.endDate.gt(now));
 
+            case COMPLETED -> book.bookStatus.eq(BookStatus.RESERVED)
+                    .and(serviceItem.status.eq(ServiceStatus.SUCCEEDED))
+                    .and(serviceItem.endDate.loe(now));
             default -> null;
         };
     }

--- a/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryImpl.java
+++ b/src/main/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryImpl.java
@@ -56,6 +56,38 @@ public class BookRepositoryImpl implements BookRepositoryCustom {
         return new PageImpl<>(content, pageable, total == null ? 0 : total);
     }
 
+    @Override
+    public Page<Book> findAllByCompanyIdAndStatus(Long companyId, BookStatusFilter status, Pageable pageable) {
+        LocalDateTime now = LocalDateTime.now();
+        BooleanExpression baseCondition = book.serviceItem.company.id.eq(companyId);
+        BooleanExpression statusCondition = statusCondition(status, now);
+
+        List<Book> content = queryFactory
+                .selectFrom(book)
+                .join(book.serviceItem, serviceItem).fetchJoin()
+                .join(book.serviceItem.company, company).fetchJoin()
+                .join(book.serviceItem.address, address1).fetchJoin()
+                .where(
+                    baseCondition,
+                    statusCondition
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(book.createdAt.desc())
+                .fetch();
+
+        Long total = queryFactory
+                .select(book.count())
+                .from(book)
+                .where(
+                        baseCondition,
+                        statusCondition
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+
     private BooleanExpression statusCondition(BookStatusFilter status, LocalDateTime now) {
         if (status == null || status == BookStatusFilter.ALL) {
             return null;

--- a/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
@@ -26,17 +26,16 @@ public class BookReadService {
     private final BookRepository bookRepository;
 
     public Page<Book> findAllByUserIdAndStatus(Long userId, BookStatusFilter status, Pageable pageable) {
-
         return bookRepository.findAllByUserIdAndStatus(userId, status, pageable);
+    }
+
+    public Page<Book> findAllByCompanyIdAndStatus(Long userId, BookStatusFilter status, Pageable pageable) {
+        return bookRepository.findAllByCompanyIdAndStatus(userId, status, pageable);
     }
 
     // 취소한 사람은 다시 신청이 가능
     public boolean existsByUserAndServiceAndStatusNot(Long userId, Long serviceId, BookStatus status) {
         return bookRepository.existsByUserIdAndServiceItemIdAndBookStatusNot(userId, serviceId, status);
-    }
-
-    public Long countRecruitingBooksByUserId(Long userId) {
-        return bookRepository.countRecruitingBooksByUserId(userId, BookStatus.RESERVED, ServiceStatus.RECRUITING, LocalDateTime.now());
     }
 
     public List<Book> findAllByServiceItemIdAndBookStatus(Long serviceItemId, BookStatus bookStatus) {
@@ -48,7 +47,19 @@ public class BookReadService {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BOOKING_NOT_FOUND));
     }
 
+    public Long countRecruitingBooksByUserId(Long userId) {
+        return bookRepository.countRecruitingBooksByUserId(userId, BookStatus.RESERVED, ServiceStatus.RECRUITING, LocalDateTime.now());
+    }
+
     public Long countSucceededBooksByUserId(Long userId) {
         return bookRepository.countSucceededBooksByUserId(userId, BookStatus.RESERVED, ServiceStatus.SUCCEEDED, LocalDateTime.now());
+    }
+
+    public Long countRecruitingBooksByCompanyId(Long companyId) {
+        return bookRepository.countRecruitingBooksByCompanyId(companyId, BookStatus.RESERVED, ServiceStatus.RECRUITING, LocalDateTime.now());
+    }
+
+    public Long countSucceededBooksByCompanyId(Long companyId) {
+        return bookRepository.countSucceededBooksByCompanyId(companyId, BookStatus.RESERVED, ServiceStatus.SUCCEEDED, LocalDateTime.now());
     }
 }

--- a/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
@@ -12,7 +12,9 @@ import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.infrastructure.repository.BookRepository;
 import teamssavice.ssavice.global.constants.ErrorCode;
 import teamssavice.ssavice.global.exception.EntityNotFoundException;
+import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -33,8 +35,8 @@ public class BookReadService {
         return bookRepository.existsByUserIdAndServiceItemIdAndBookStatusNot(userId, serviceId, status);
     }
 
-    public List<Book> findByUserIdAndBookStatus(Long userId, BookStatus bookStatus) {
-        return bookRepository.findByUserIdAndBookStatus(userId, bookStatus);
+    public Long countRecruitingBooksByUserId(Long userId) {
+        return bookRepository.countRecruitingBooksByUserId(userId, BookStatus.RESERVED, ServiceStatus.RECRUITING, LocalDateTime.now());
     }
 
     public List<Book> findAllByServiceItemIdAndBookStatus(Long serviceItemId, BookStatus bookStatus) {
@@ -44,5 +46,9 @@ public class BookReadService {
     public Book findFirstByUserIdAndServiceItemIdOrderByCreatedAtDesc(Long userId, Long serviceItemId) {
         return bookRepository.findFirstByUserIdAndServiceItemIdOrderByCreatedAtDesc(userId, serviceItemId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BOOKING_NOT_FOUND));
+    }
+
+    public Long countSucceededBooksByUserId(Long userId) {
+        return bookRepository.countSucceededBooksByUserId(userId, BookStatus.RESERVED, ServiceStatus.SUCCEEDED, LocalDateTime.now());
     }
 }

--- a/src/main/java/teamssavice/ssavice/book/service/BookService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookService.java
@@ -5,13 +5,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import teamssavice.ssavice.book.entity.BookStatus;
 import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.service.dto.BookCommand;
 import teamssavice.ssavice.book.service.dto.BookModel;
-import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,14 +24,8 @@ public class BookService {
 
     @Transactional(readOnly = true)
     public BookModel.BookSummary getBookSummary(Long userId) {
-        List<Book> books = bookReadService.findByUserIdAndBookStatus(userId, BookStatus.RESERVED);
-        Long applying = 0L;
-        Long completedCount = 0L;
-        for (Book book : books) {
-            if(book.getServiceItem().getStatus() == ServiceStatus.RECRUITING) applying++;
-            else if(book.getServiceItem().getStatus() == ServiceStatus.SUCCEEDED ||
-                    book.getServiceItem().getStatus() == ServiceStatus.FULLED) completedCount++;
-        }
+        Long applying = bookReadService.countRecruitingBooksByUserId(userId);
+        Long completedCount = bookReadService.countSucceededBooksByUserId(userId);
 
         return BookModel.BookSummary.from(applying, completedCount);
     }

--- a/src/main/java/teamssavice/ssavice/book/service/BookService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookService.java
@@ -18,7 +18,7 @@ public class BookService {
     @Transactional(readOnly = true)
     public Page<BookModel.Info> getMyBooksByStatus(BookCommand.RetrieveByStatus command) {
 
-        Page<Book> books = bookReadService.findAllByUserIdAndStatus(command.userId(), command.status(), command.pageable());
+        Page<Book> books = bookReadService.findAllByUserIdAndStatus(command.id(), command.status(), command.pageable());
         return books.map(BookModel.Info::from);
     }
 
@@ -26,6 +26,20 @@ public class BookService {
     public BookModel.BookSummary getBookSummary(Long userId) {
         Long applying = bookReadService.countRecruitingBooksByUserId(userId);
         Long completedCount = bookReadService.countSucceededBooksByUserId(userId);
+
+        return BookModel.BookSummary.from(applying, completedCount);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<BookModel.Info> getMyCompanysBooksByStatus(BookCommand.RetrieveByStatus command) {
+        Page<Book> books = bookReadService.findAllByCompanyIdAndStatus(command.id(), command.status(), command.pageable());
+        return books.map(BookModel.Info::from);
+    }
+
+    @Transactional(readOnly = true)
+    public BookModel.BookSummary getCompanysBookSummary(Long companyId) {
+        Long applying = bookReadService.countRecruitingBooksByCompanyId(companyId);
+        Long completedCount = bookReadService.countSucceededBooksByCompanyId(companyId);
 
         return BookModel.BookSummary.from(applying, completedCount);
     }

--- a/src/main/java/teamssavice/ssavice/book/service/dto/BookCommand.java
+++ b/src/main/java/teamssavice/ssavice/book/service/dto/BookCommand.java
@@ -9,14 +9,14 @@ public class BookCommand {
 
     @Builder
     public record RetrieveByStatus(
-        Long userId,
+        Long id,
         Pageable pageable,
         BookStatusFilter status
     ) {
 
-        public static RetrieveByStatus of(Long userId, Pageable pageable, BookStatusFilter status) {
+        public static RetrieveByStatus of(Long id, Pageable pageable, BookStatusFilter status) {
             return RetrieveByStatus.builder()
-                .userId(userId)
+                .id(id)
                 .pageable(pageable)
                 .status(status)
                 .build();

--- a/src/main/java/teamssavice/ssavice/serviceItem/entity/ServiceItem.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/entity/ServiceItem.java
@@ -96,6 +96,10 @@ public class ServiceItem extends BaseEntity {
     @Column(name = "image_id")
     private List<Long> imageIds = new ArrayList<>();
 
+    @Builder.Default
+    @Column(nullable = false)
+    private ServiceStatus status = ServiceStatus.RECRUITING;
+
     public void addImageId(Long id) {
         imageIds.add(id);
     }
@@ -105,23 +109,26 @@ public class ServiceItem extends BaseEntity {
     }
 
     public ServiceStatus getStatus() {
-        if(this.isDeleted) return ServiceStatus.CANCELED;
-        if(isInUse()) return ServiceStatus.IN_USE;
-        if(isCompleted()) return ServiceStatus.COMPLETED;
-        if(isFull()) return ServiceStatus.FULLED;
-        if (isTimeOver()) {
-            if(!isReachedMinimum()) return ServiceStatus.FAILED;
-            return ServiceStatus.FULLED;
+        if(status == ServiceStatus.RECRUITING) {
+            if(isTimeOver()) return ServiceStatus.FAILED;
+        } else if (status == ServiceStatus.SUCCEEDED) {
+            if(isCompleted()) return ServiceStatus.COMPLETED;
+            else if(isInUse()) return ServiceStatus.IN_USE;
+            else if(isTimeOver() || isFull()) return ServiceStatus.FULLED;
         }
-        if(isReachedMinimum()) return ServiceStatus.SUCCEEDED;
-        return ServiceStatus.RECRUITING;
+        return status;
     }
 
     public void participate() {
         if (this.isFull()) {
             throw new ConflictException(ErrorCode.MEMBER_FULL);
         }
+        // 마감 기한 확인
+        if (isTimeOver()) {
+            throw new ConflictException(ErrorCode.SERVICE_DEADLINE_EXPIRED);
+        }
         this.currentMember++;
+        if(isReachedMinimum()) status = ServiceStatus.SUCCEEDED;
     }
 
     public boolean isReachedMinimum() {
@@ -158,12 +165,6 @@ public class ServiceItem extends BaseEntity {
             case COMPLETED -> throw new ConflictException(ErrorCode.SERVICE_ALREADY_COMPLETED);
             case FULLED -> throw new ConflictException(ErrorCode.MEMBER_FULL);
         }
-
-
-        // 마감 기한 확인
-        if (isTimeOver()) {
-            throw new ConflictException(ErrorCode.SERVICE_DEADLINE_EXPIRED);
-        }
     }
 
     public void delete() {
@@ -176,6 +177,7 @@ public class ServiceItem extends BaseEntity {
         }
 
         this.isDeleted = true;
+        status = ServiceStatus.CANCELED;
     }
 
     public void cancelParticipation() {

--- a/src/main/java/teamssavice/ssavice/serviceItem/infrastructure/repository/ServiceItemRepository.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/infrastructure/repository/ServiceItemRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import teamssavice.ssavice.company.entity.Company;
+import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 
 import java.time.LocalDateTime;
@@ -18,8 +19,7 @@ public interface ServiceItemRepository extends JpaRepository<ServiceItem, Long>,
 
     @Query("SELECT s FROM ServiceItem s " +
             "WHERE s.company.id = :companyId " +
-            "AND s.isDeleted = false " +
-            "AND s.deadline > :now " +
-            "AND s.currentMember < s.maximumMember")
-    Page<ServiceItem> findAllRecruitingByCompany_Id(Long companyId, LocalDateTime now, Pageable pageable);
+            "AND s.status = :status " +
+            "AND s.deadline > :now")
+    Page<ServiceItem> findAllByCompany_IdAndStatus(Long companyId, ServiceStatus status, LocalDateTime now, Pageable pageable);
 }

--- a/src/main/java/teamssavice/ssavice/serviceItem/infrastructure/repository/ServiceItemRepositoryImpl.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/infrastructure/repository/ServiceItemRepositoryImpl.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 import teamssavice.ssavice.serviceItem.service.dto.ServiceItemCommand;
 
@@ -103,8 +104,7 @@ public class ServiceItemRepositoryImpl implements ServiceItemRepositoryCustom {
         if(!onSale) return null;
         LocalDateTime now = LocalDateTime.now();
 
-        return serviceItem.isDeleted.isFalse()
-                .and(serviceItem.deadline.gt(now))
-                .and(serviceItem.currentMember.lt(serviceItem.maximumMember));
+        return serviceItem.status.eq(ServiceStatus.RECRUITING)
+                .and(serviceItem.deadline.gt(now));
     }
 }

--- a/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemReadService.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemReadService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import teamssavice.ssavice.company.entity.Company;
 import teamssavice.ssavice.global.constants.ErrorCode;
 import teamssavice.ssavice.global.exception.EntityNotFoundException;
+import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 import teamssavice.ssavice.serviceItem.infrastructure.repository.ServiceItemRepository;
 import teamssavice.ssavice.serviceItem.service.dto.ServiceItemCommand;
@@ -45,7 +46,7 @@ public class ServiceItemReadService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ServiceItem> findAllRecruitingByCompany_Id(Long companyId, Pageable pageable) {
-        return serviceItemRepository.findAllRecruitingByCompany_Id(companyId, LocalDateTime.now(), pageable);
+    public Page<ServiceItem> findAllByCompany_IdAndStatus(Long companyId, ServiceStatus status, Pageable pageable) {
+        return serviceItemRepository.findAllByCompany_IdAndStatus(companyId, status, LocalDateTime.now(), pageable);
     }
 }

--- a/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemService.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemService.java
@@ -26,6 +26,7 @@ import teamssavice.ssavice.region.Region;
 import teamssavice.ssavice.region.RegionReadService;
 import teamssavice.ssavice.s3.S3Service;
 import teamssavice.ssavice.s3.event.S3EventDto;
+import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 import teamssavice.ssavice.serviceItem.service.dto.ServiceItemCommand;
 import teamssavice.ssavice.serviceItem.service.dto.ServiceItemModel;
@@ -120,7 +121,7 @@ public class ServiceItemService {
 
     public Page<ServiceItemModel.Summary> getServiceByCompanyAndStatus(ServiceItemCommand.RetrieveByCompanyAndOnSale command) {
         if (command.onSale()) {
-            Page<ServiceItem> serviceItems = serviceItemReadService.findAllRecruitingByCompany_Id(command.companyId(), command.pageable());
+            Page<ServiceItem> serviceItems = serviceItemReadService.findAllByCompany_IdAndStatus(command.companyId(), ServiceStatus.RECRUITING, command.pageable());
             return serviceItems.map(ServiceItemModel.Summary::from);
         }
         Page<ServiceItem> serviceItems = serviceItemReadService.findAllByCompany_Id(command.companyId(), command.pageable());

--- a/src/test/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryImplTest.java
+++ b/src/test/java/teamssavice/ssavice/book/infrastructure/repository/BookRepositoryImplTest.java
@@ -102,9 +102,26 @@ class BookRepositoryImplTest {
         Page<BookModel.Info> actualModels = actuals.map(BookModel.Info::from);
 
         // then
-        assertThat(actualModels.getTotalElements()).isEqualTo(2);
+        assertThat(actualModels.getTotalElements()).isEqualTo(1);
         for (BookModel.Info model : actualModels) {
-            assertThat(model.bookStatus()).isIn(BookViewStatus.RECRUITING, BookViewStatus.SUCCEEDED);
+            assertThat(model.bookStatus()).isEqualTo(BookViewStatus.RECRUITING);
+        }
+    }
+
+    @Test
+    @DisplayName("BookStatusFilter가 SUCCEEDED일 때 findAllByUserIdAndStatus() 테스트")
+    void findAllByUserIdAndStatusTestWhenSucceeded() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when
+        Page<Book> actuals = bookRepository.findAllByUserIdAndStatus(user.getId(), BookStatusFilter.SUCCEEDED, pageable);
+        Page<BookModel.Info> actualModels = actuals.map(BookModel.Info::from);
+
+        // then
+        assertThat(actualModels.getTotalElements()).isEqualTo(3);
+        for (BookModel.Info model : actualModels) {
+            assertThat(model.bookStatus()).isIn(BookViewStatus.SUCCEEDED, BookViewStatus.FULLED, BookViewStatus.IN_USE);
         }
     }
 
@@ -119,9 +136,9 @@ class BookRepositoryImplTest {
         Page<BookModel.Info> actualModels = actuals.map(BookModel.Info::from);
 
         // then
-        assertThat(actualModels.getTotalElements()).isEqualTo(3);
+        assertThat(actualModels.getTotalElements()).isEqualTo(1);
         for (BookModel.Info model : actualModels) {
-            assertThat(model.bookStatus()).isIn(BookViewStatus.FULLED, BookViewStatus.IN_USE, BookViewStatus.COMPLETED);
+            assertThat(model.bookStatus()).isEqualTo(BookViewStatus.COMPLETED);
         }
     }
 

--- a/src/test/java/teamssavice/ssavice/book/service/BookServiceTest.java
+++ b/src/test/java/teamssavice/ssavice/book/service/BookServiceTest.java
@@ -1,26 +1,15 @@
 package teamssavice.ssavice.book.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import teamssavice.ssavice.book.entity.BookStatus;
-import teamssavice.ssavice.book.entity.Book;
 import teamssavice.ssavice.book.service.dto.BookModel;
-import teamssavice.ssavice.fixture.BookFixture;
-import teamssavice.ssavice.fixture.ServiceItemFixture;
-import teamssavice.ssavice.fixture.UserFixture;
-import teamssavice.ssavice.user.entity.Users;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class BookServiceTest {
@@ -31,17 +20,6 @@ class BookServiceTest {
     @Mock
     private BookReadService bookReadService;
 
-    private final List<Book> books = new ArrayList<>();
-
-    @BeforeEach
-    void setUp() {
-        Users user = UserFixture.user();
-        for (int i = 0; i < 5; i++) {
-            books.add(BookFixture.book(user, ServiceItemFixture.fulled(null), BookStatus.RESERVED));
-            books.add(BookFixture.book(user, ServiceItemFixture.recruiting(null), BookStatus.RESERVED));
-        }
-    }
-
     @Test
     @DisplayName("사용자의 예약 요약 정보 조회 시, 각 상태별 카운트가 정확히 합산되어 반환된다")
     void getBookSummary_test() {
@@ -50,25 +28,21 @@ class BookServiceTest {
 
         // Mock 데이터 설정
         Long recruitingCount = 5L; // 모집 중
-        Long completedCount = 5L;  // 모집 성공 및 마감
+        Long completedCount = 6L;  // 모집 성공 및 마감
 
         // 각 상태별로 호출될 때 반환할 값 지정
-        given(bookReadService.findByUserIdAndBookStatus(userId, BookStatus.RESERVED))
-                .willReturn(books);
+        given(bookReadService.countRecruitingBooksByUserId(userId))
+                .willReturn(recruitingCount);
+        given(bookReadService.countSucceededBooksByUserId(userId))
+                .willReturn(completedCount);
 
         // when
         BookModel.BookSummary result = bookService.getBookSummary(userId);
 
         // then
         // 1. 결과 DTO의 필드 검증
-        // applying = recruitingCount (5)
-        assertThat(result.applying()).isEqualTo(5L);
+        assertThat(result.applying()).isEqualTo(recruitingCount);
 
-        // completed(모집완료) = succeededCount(3) + closedCount(2) = 5
-        assertThat(result.completed()).isEqualTo(5L);
-
-        // 2. 각 메서드가 정확히 호출되었는지 검증
-        verify(bookReadService).findByUserIdAndBookStatus(
-                userId, BookStatus.RESERVED);
+        assertThat(result.completed()).isEqualTo(completedCount);
     }
 }

--- a/src/test/java/teamssavice/ssavice/fixture/ServiceItemFixture.java
+++ b/src/test/java/teamssavice/ssavice/fixture/ServiceItemFixture.java
@@ -2,6 +2,7 @@ package teamssavice.ssavice.fixture;
 
 import teamssavice.ssavice.address.Address;
 import teamssavice.ssavice.company.entity.Company;
+import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.Price;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 
@@ -80,7 +81,9 @@ public class ServiceItemFixture {
     }
 
     public static ServiceItem recruiting(Company company) {
-        return base(company);
+        return base(company).toBuilder()
+                .status(ServiceStatus.RECRUITING)
+                .build();
     }
 
     public static ServiceItem succeeded(Company company) {
@@ -88,6 +91,7 @@ public class ServiceItemFixture {
                 .currentMember(11L)
                 .minimumMember(10L)
                 .maximumMember(20L)
+                .status(ServiceStatus.SUCCEEDED)
                 .build();
     }
 
@@ -96,6 +100,7 @@ public class ServiceItemFixture {
                 .currentMember(20L)
                 .minimumMember(10L)
                 .maximumMember(20L)
+                .status(ServiceStatus.SUCCEEDED)
                 .build();
     }
 
@@ -104,6 +109,7 @@ public class ServiceItemFixture {
                 .deadline(LocalDateTime.now().minusDays(20))
                 .startDate(LocalDateTime.now().minusDays(5))
                 .endDate(LocalDateTime.now().plusDays(5))
+                .status(ServiceStatus.SUCCEEDED)
                 .build();
     }
 
@@ -112,18 +118,21 @@ public class ServiceItemFixture {
                 .deadline(LocalDateTime.now().minusDays(20))
                 .startDate(LocalDateTime.now().minusDays(5))
                 .endDate(LocalDateTime.now().minusDays(1))
+                .status(ServiceStatus.SUCCEEDED)
                 .build();
     }
 
     public static ServiceItem failed(Company company) {
         return base(company).toBuilder()
                 .deadline(LocalDateTime.now().minusDays(1))
+                .status(ServiceStatus.RECRUITING)
                 .build();
     }
 
     public static ServiceItem canceled(Company company) {
         return base(company).toBuilder()
                 .isDeleted(true)
+                .status(ServiceStatus.CANCELED)
                 .build();
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용
* ServiceStatus 복구
> Recruiting(recruiting, failed), Succeeded(Fulled(max초과, deadline초과), succeeded, in_use, completed), Canceled
* getStatus 로직 변경
* participate 로직 변경
* getBookSummary() 로직 변경
* findAllByUserIdAndStatus()의 QueryDSL 로직 변경

## 이미지 첨부
### getStatus()
<img width="662" height="246" alt="image" src="https://github.com/user-attachments/assets/3d69b1a9-e969-409c-a5eb-583d53bbcb14" />

### participate()
<img width="634" height="272" alt="image" src="https://github.com/user-attachments/assets/d9254096-f262-41e3-becf-e90c091db061" />

### getBookSummary()
<img width="645" height="170" alt="image" src="https://github.com/user-attachments/assets/d5edd596-26c8-48b8-ad5f-eadcfb9a5ad8" />

### count JPQL
<img width="929" height="363" alt="image" src="https://github.com/user-attachments/assets/775248ad-7a55-4c86-b930-f0109ffda046" />

### QueryDSL
<img width="736" height="650" alt="image" src="https://github.com/user-attachments/assets/c5a3c1bb-13fb-46a1-886b-e1dcd49eb5f0" />


## To Reviewers 📢
<!-- 리뷰어에게 질문할 사항이나 추가 설명, 요청이 필요한 부분을 여기에 적어주세요. -->

## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [x] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [x] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #88 
