### PR TITLE
Week10/issue#126 Company 권한이나 비회원도 SearchDetail 조회가 가능하도록 변경

### DIFF
--- a/src/main/java/teamssavice/ssavice/auth/controller/AuthController.java
+++ b/src/main/java/teamssavice/ssavice/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import teamssavice.ssavice.auth.controller.dto.AuthResponse;
 import teamssavice.ssavice.auth.service.TokenService;
 import teamssavice.ssavice.auth.service.dto.AuthModel;
 import teamssavice.ssavice.global.annotation.CurrentRefreshToken;
+import teamssavice.ssavice.global.annotation.PermitAll;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,6 +17,7 @@ import teamssavice.ssavice.global.annotation.CurrentRefreshToken;
 public class AuthController {
     private final TokenService tokenService;
 
+    @PermitAll
     @GetMapping("token/refresh")
     public ResponseEntity<AuthResponse.Refresh> refresh(
             @CurrentRefreshToken String refreshToken
@@ -24,6 +26,7 @@ public class AuthController {
         return ResponseEntity.ok(AuthResponse.Refresh.from(model));
     }
 
+    @PermitAll
     @GetMapping("/logout")
     public ResponseEntity<Void> logout(
             @CurrentRefreshToken String refreshToken

--- a/src/main/java/teamssavice/ssavice/book/controller/BookController.java
+++ b/src/main/java/teamssavice/ssavice/book/controller/BookController.java
@@ -13,8 +13,9 @@ import teamssavice.ssavice.book.controller.dto.BookResponse;
 import teamssavice.ssavice.book.service.BookService;
 import teamssavice.ssavice.book.service.dto.BookCommand;
 import teamssavice.ssavice.book.service.dto.BookModel;
-import teamssavice.ssavice.global.annotation.CurrentId;
+import teamssavice.ssavice.global.annotation.CurrentAuth;
 import teamssavice.ssavice.global.annotation.RequireRole;
+import teamssavice.ssavice.global.dto.Auth;
 import teamssavice.ssavice.global.dto.PageResponse;
 import teamssavice.ssavice.serviceItem.service.dto.ServiceItemCommand;
 
@@ -29,12 +30,12 @@ public class BookController {
     @GetMapping("/user")
     @RequireRole(Role.USER)
     public ResponseEntity<PageResponse<BookResponse.Info>> getMyBooksByStatus(
-        @CurrentId Long userId,
-        @PageableDefault(size = 10) Pageable pageable,
-        @RequestParam BookStatusFilter status
+            @CurrentAuth Auth authUser,
+            @PageableDefault(size = 10) Pageable pageable,
+            @RequestParam BookStatusFilter status
     ) {
 
-        BookCommand.RetrieveByStatus command = BookCommand.RetrieveByStatus.of(userId, pageable, status);
+        BookCommand.RetrieveByStatus command = BookCommand.RetrieveByStatus.of(authUser.id(), pageable, status);
 
         Page<BookModel.Info> models = bookService.getMyBooksByStatus(command);
         Page<BookResponse.Info> responsePage = models.map(BookResponse.Info::from);
@@ -45,9 +46,9 @@ public class BookController {
     @GetMapping("/user/summary")
     @RequireRole(Role.USER)
     public ResponseEntity<BookResponse.Count> getBookSummary(
-        @CurrentId Long userId
+            @CurrentAuth Auth authUser
     ) {
-        BookModel.Count model = bookService.getBookSummary(userId);
+        BookModel.Count model = bookService.getBookSummary(authUser.id());
 
         return ResponseEntity.ok(BookResponse.Count.from(model));
     }
@@ -55,10 +56,10 @@ public class BookController {
     @PostMapping("/{serviceId}/apply")
     @RequireRole(Role.USER)
     public ResponseEntity<BookResponse.Apply> applyServiceItem(
-            @CurrentId Long userId,
+            @CurrentAuth Auth authUser,
             @PathVariable Long serviceId
     ) {
-        BookModel.Apply model = bookService.apply(userId, serviceId);
+        BookModel.Apply model = bookService.apply(authUser.id(), serviceId);
         return ResponseEntity.ok(BookResponse.Apply.from(model));
     }
 
@@ -66,21 +67,21 @@ public class BookController {
     @PostMapping("/{serviceId}/cancel")
     @RequireRole(Role.USER)
     public ResponseEntity<Void> cancelParticipation(
-            @CurrentId Long userId,
+            @CurrentAuth Auth authUser,
             @PathVariable Long serviceId
     ) {
-        bookService.cancel(ServiceItemCommand.Cancel.of(userId, serviceId));
+        bookService.cancel(ServiceItemCommand.Cancel.of(authUser.id(), serviceId));
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/book/{service-id}/participant")
     @RequireRole(Role.COMPANY)
     public ResponseEntity<PageResponse<BookResponse.Participant>> getParticipants(
-        @CurrentId Long companyId,
+        @CurrentAuth Auth authCompany,
         @PathVariable("service-id") Long serviceItemId,
         @PageableDefault(size = 10) Pageable pageable
     ) {
-        Page<BookModel.Participant> models = bookService.getParticipants(companyId, serviceItemId,
+        Page<BookModel.Participant> models = bookService.getParticipants(authCompany.id(), serviceItemId,
             pageable);
         Page<BookResponse.Participant> responsePage = models.map(BookResponse.Participant::from);
 

--- a/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
@@ -17,7 +17,9 @@ import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 
@@ -46,8 +48,7 @@ public class BookReadService {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BOOKING_NOT_FOUND));
     }
 
-    public boolean isBookedByUserIdAndServiceId(@Nullable Long userId, Long serviceItemId) {
-        if(userId == null) return false;
+    public boolean isBookedByUserIdAndServiceId(Long userId, Long serviceItemId) {
         return bookRepository.findFirstByUserIdAndServiceItemIdOrderByCreatedAtDesc(userId, serviceItemId)
                 .map(book -> book.getBookStatus() == BookStatus.RESERVED)
                 .orElse(false);

--- a/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
+++ b/src/main/java/teamssavice/ssavice/book/service/BookReadService.java
@@ -4,6 +4,7 @@ package teamssavice.ssavice.book.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamssavice.ssavice.book.constants.BookStatusFilter;
@@ -16,8 +17,7 @@ import teamssavice.ssavice.serviceItem.constants.ServiceStatus;
 import teamssavice.ssavice.serviceItem.entity.ServiceItem;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 
@@ -46,7 +46,8 @@ public class BookReadService {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BOOKING_NOT_FOUND));
     }
 
-    public boolean isBookedByUserIdAndServiceId(Long userId, Long serviceItemId) {
+    public boolean isBookedByUserIdAndServiceId(@Nullable Long userId, Long serviceItemId) {
+        if(userId == null) return false;
         return bookRepository.findFirstByUserIdAndServiceItemIdOrderByCreatedAtDesc(userId, serviceItemId)
                 .map(book -> book.getBookStatus() == BookStatus.RESERVED)
                 .orElse(false);
@@ -60,15 +61,17 @@ public class BookReadService {
         return bookRepository.countSucceededBooksByUserId(userId, BookStatus.RESERVED, ServiceStatus.SUCCEEDED, LocalDateTime.now());
     }
 
-    public Set<Long> findReservedServiceItemIdsFromLatestBooks(Long userId, List<ServiceItem> serviceItems) {
+    public Set<Long> findReservedServiceItemIdsFromLatestBooks(@Nullable Long userId, List<ServiceItem> serviceItems) {
+        if(userId == null) return Collections.emptySet();
+
         List<Long> serviceIds = serviceItems.stream()
-            .map(ServiceItem::getId)
-            .toList();
+                .map(ServiceItem::getId)
+                .toList();
 
         return bookRepository.findLatestBooksByUserIdAndServiceItemId(userId, serviceIds).stream()
-            .filter(book -> book.getBookStatus() == BookStatus.RESERVED)
-            .map(book -> book.getServiceItem().getId())
-            .collect(Collectors.toSet());
+                .filter(book -> book.getBookStatus() == BookStatus.RESERVED)
+                .map(book -> book.getServiceItem().getId())
+                .collect(Collectors.toSet());
     }
   
     public Long countAllBooksByUserId(Long userId) {

--- a/src/main/java/teamssavice/ssavice/company/controller/CompanyController.java
+++ b/src/main/java/teamssavice/ssavice/company/controller/CompanyController.java
@@ -21,6 +21,7 @@ import teamssavice.ssavice.company.service.CompanyService;
 import teamssavice.ssavice.company.service.dto.CompanyCommand;
 import teamssavice.ssavice.company.service.dto.CompanyModel;
 import teamssavice.ssavice.global.annotation.CurrentId;
+import teamssavice.ssavice.global.annotation.PermitAll;
 import teamssavice.ssavice.global.annotation.RequireRole;
 import teamssavice.ssavice.imageresource.ImageRequest;
 import teamssavice.ssavice.imageresource.ImageResponse;
@@ -40,6 +41,7 @@ public class CompanyController {
     private final ImageService imageService;
     private final S3Service s3Service;
 
+    @PermitAll
     @PostMapping("/login")
     public ResponseEntity<CompanyResponse.Login> login(
         @RequestBody @Valid CompanyRequest.Login request

--- a/src/main/java/teamssavice/ssavice/company/controller/CompanyController.java
+++ b/src/main/java/teamssavice/ssavice/company/controller/CompanyController.java
@@ -48,8 +48,8 @@ public class CompanyController {
         return ResponseEntity.ok(CompanyResponse.Login.from(model));
     }
 
-    @RequireRole(Role.USER)
     @PostMapping
+    @RequireRole(Role.USER)
     public ResponseEntity<CompanyResponse.Login> register(
         @CurrentId Long userId,
         @RequestBody @Valid CompanyRequest.Create request
@@ -59,8 +59,8 @@ public class CompanyController {
         return ResponseEntity.ok(CompanyResponse.Login.from(model));
     }
 
-    @RequireRole(Role.COMPANY)
     @PutMapping
+    @RequireRole(Role.COMPANY)
     public ResponseEntity<CompanyResponse> putCompany(
         @CurrentId Long companyId,
         @RequestBody @Valid CompanyRequest.Update request
@@ -69,8 +69,8 @@ public class CompanyController {
         return ResponseEntity.ok().build();
     }
 
-    @RequireRole(Role.COMPANY)
     @GetMapping
+    @RequireRole(Role.COMPANY)
     public ResponseEntity<CompanyResponse.MyCompany> getCompany(
         @CurrentId Long companyId
     ) {

--- a/src/main/java/teamssavice/ssavice/company/controller/CompanyController.java
+++ b/src/main/java/teamssavice/ssavice/company/controller/CompanyController.java
@@ -20,9 +20,10 @@ import teamssavice.ssavice.company.controller.dto.CompanyResponse;
 import teamssavice.ssavice.company.service.CompanyService;
 import teamssavice.ssavice.company.service.dto.CompanyCommand;
 import teamssavice.ssavice.company.service.dto.CompanyModel;
-import teamssavice.ssavice.global.annotation.CurrentId;
+import teamssavice.ssavice.global.annotation.CurrentAuth;
 import teamssavice.ssavice.global.annotation.PermitAll;
 import teamssavice.ssavice.global.annotation.RequireRole;
+import teamssavice.ssavice.global.dto.Auth;
 import teamssavice.ssavice.imageresource.ImageRequest;
 import teamssavice.ssavice.imageresource.ImageResponse;
 import teamssavice.ssavice.imageresource.constants.ImageContentType;
@@ -53,33 +54,34 @@ public class CompanyController {
     @PostMapping
     @RequireRole(Role.USER)
     public ResponseEntity<CompanyResponse.Login> register(
-        @CurrentId Long userId,
+        @CurrentAuth Auth authUser,
         @RequestBody @Valid CompanyRequest.Create request
     ) {
         CompanyModel.Login model = companyService.register(
-            CompanyCommand.Create.from(userId, request));
+            CompanyCommand.Create.from(authUser.id(), request));
         return ResponseEntity.ok(CompanyResponse.Login.from(model));
     }
 
     @PutMapping
     @RequireRole(Role.COMPANY)
     public ResponseEntity<CompanyResponse> putCompany(
-        @CurrentId Long companyId,
+        @CurrentAuth Auth authCompany,
         @RequestBody @Valid CompanyRequest.Update request
     ) {
-        companyService.updateCompany(CompanyCommand.Update.from(companyId, request));
+        companyService.updateCompany(CompanyCommand.Update.from(authCompany.id(), request));
         return ResponseEntity.ok().build();
     }
 
     @GetMapping
     @RequireRole(Role.COMPANY)
     public ResponseEntity<CompanyResponse.MyCompany> getCompany(
-        @CurrentId Long companyId
+        @CurrentAuth Auth authCompany
     ) {
-        CompanyModel.MyCompany model = companyService.getMyCompany(companyId);
+        CompanyModel.MyCompany model = companyService.getMyCompany(authCompany.id());
         return ResponseEntity.ok(CompanyResponse.MyCompany.from(model));
     }
 
+    @PermitAll
     @GetMapping("/{company-id}")
     public ResponseEntity<CompanyResponse.Info> getCompanyById(
         @PathVariable("company-id") @Positive Long companyId
@@ -88,6 +90,7 @@ public class CompanyController {
         return ResponseEntity.ok(CompanyResponse.Info.from(model));
     }
 
+    @PermitAll
     @GetMapping("/{company-id}/summary")
     public ResponseEntity<CompanyResponse.Summary> getCompanySummary(
         @PathVariable("company-id") @Positive Long companyId
@@ -99,10 +102,10 @@ public class CompanyController {
     @PostMapping("/image")
     @RequireRole(Role.COMPANY)
     public ResponseEntity<ImageResponse.PresignedUrl> createCompanyPresignedUrl(
-        @CurrentId Long userId,
+        @CurrentAuth Auth authCompany,
         @RequestBody @Valid ImageRequest.ContentType request
     ) {
-        ImageModel.PutPresignedUrl model = imageService.updateImage(userId, ImagePath.company,
+        ImageModel.PutPresignedUrl model = imageService.updateImage(authCompany.id(), ImagePath.company,
             ImageContentType.from(request.contentType()));
         return ResponseEntity.ok(ImageResponse.PresignedUrl.from(model));
     }
@@ -110,11 +113,11 @@ public class CompanyController {
     @PostMapping("/image/confirm")
     @RequireRole(Role.COMPANY)
     public ResponseEntity<Void> confirmCompanyImageUpload(
-        @CurrentId Long companyId,
+        @CurrentAuth Auth authCompany,
         @RequestBody @Valid ImageRequest.Confirm request
     ) {
         s3Service.validateTempImageOrDelete(request.objectKey());
-        companyService.updateCompanyImage(companyId, request.objectKey());
+        companyService.updateCompanyImage(authCompany.id(), request.objectKey());
         return ResponseEntity.ok().build();
     }
 
@@ -122,10 +125,10 @@ public class CompanyController {
     @PostMapping("/validate")
     @RequireRole(Role.USER)
     public ResponseEntity<CompanyResponse.Validate> validateBusiness(
-        @CurrentId Long userId,
+        @CurrentAuth Auth authUser,
         @RequestBody @Valid CompanyRequest.Validate request
     ) {
-        CompanyModel.Validate model = companyService.validateBusinessNumber(userId,
+        CompanyModel.Validate model = companyService.validateBusinessNumber(authUser.id(),
             request.toCommand());
         return ResponseEntity.ok(CompanyResponse.Validate.from(model));
     }
@@ -133,9 +136,9 @@ public class CompanyController {
     @GetMapping("/address")
     @RequireRole(Role.COMPANY)
     public ResponseEntity<AddressResponse.RegionDetail> getAddress(
-            @CurrentId Long companyId
+            @CurrentAuth Auth authCompany
     ) {
-        AddressModel.RegionDetail model = companyService.getCompanyAddress(companyId);
+        AddressModel.RegionDetail model = companyService.getCompanyAddress(authCompany.id());
         return ResponseEntity.ok(AddressResponse.RegionDetail.from(model));
     }
 }

--- a/src/main/java/teamssavice/ssavice/global/annotation/CurrentAuth.java
+++ b/src/main/java/teamssavice/ssavice/global/annotation/CurrentAuth.java
@@ -7,6 +7,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CurrentId {
+public @interface CurrentAuth {
 
 }

--- a/src/main/java/teamssavice/ssavice/global/annotation/CurrentAuth.java
+++ b/src/main/java/teamssavice/ssavice/global/annotation/CurrentAuth.java
@@ -8,5 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CurrentAuth {
-
+    boolean required() default true;
 }

--- a/src/main/java/teamssavice/ssavice/global/annotation/PermitAll.java
+++ b/src/main/java/teamssavice/ssavice/global/annotation/PermitAll.java
@@ -1,0 +1,9 @@
+package teamssavice.ssavice.global.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PermitAll {
+
+}

--- a/src/main/java/teamssavice/ssavice/global/annotation/RequireRole.java
+++ b/src/main/java/teamssavice/ssavice/global/annotation/RequireRole.java
@@ -8,6 +8,5 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface RequireRole {
-
     Role value();
 }

--- a/src/main/java/teamssavice/ssavice/global/config/SwaggerConfig.java
+++ b/src/main/java/teamssavice/ssavice/global/config/SwaggerConfig.java
@@ -8,13 +8,13 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import teamssavice.ssavice.global.annotation.CurrentId;
+import teamssavice.ssavice.global.annotation.CurrentAuth;
 
 @Configuration
 public class SwaggerConfig {
 
     static {
-        SpringDocUtils.getConfig().addAnnotationsToIgnore(CurrentId.class);
+        SpringDocUtils.getConfig().addAnnotationsToIgnore(CurrentAuth.class);
     }
 
     @Bean

--- a/src/main/java/teamssavice/ssavice/global/config/WebMvcConfig.java
+++ b/src/main/java/teamssavice/ssavice/global/config/WebMvcConfig.java
@@ -7,7 +7,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import teamssavice.ssavice.global.interceptor.AuthenticationInterceptor;
 import teamssavice.ssavice.global.interceptor.AuthorizationInterceptor;
-import teamssavice.ssavice.global.resolver.CurrentIdArgumentResolver;
+import teamssavice.ssavice.global.resolver.CurrentAuthArgumentResolver;
 import teamssavice.ssavice.global.resolver.RefreshTokenArgumentResolver;
 
 import java.util.List;
@@ -26,8 +26,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
     }
 
     @Bean
-    public CurrentIdArgumentResolver currentIdArgumentResolver() {
-        return new CurrentIdArgumentResolver();
+    public CurrentAuthArgumentResolver currentAuthArgumentResolver() {
+        return new CurrentAuthArgumentResolver();
     }
 
     @Bean
@@ -48,7 +48,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(currentIdArgumentResolver());
+        resolvers.add(currentAuthArgumentResolver());
         resolvers.add(refreshTokenArgumentResolver());
     }
 }

--- a/src/main/java/teamssavice/ssavice/global/config/WebMvcConfig.java
+++ b/src/main/java/teamssavice/ssavice/global/config/WebMvcConfig.java
@@ -5,7 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import teamssavice.ssavice.global.interceptor.RequireRoleInterceptor;
+import teamssavice.ssavice.global.interceptor.AuthenticationInterceptor;
+import teamssavice.ssavice.global.interceptor.AuthorizationInterceptor;
 import teamssavice.ssavice.global.resolver.CurrentIdArgumentResolver;
 import teamssavice.ssavice.global.resolver.RefreshTokenArgumentResolver;
 
@@ -15,8 +16,13 @@ import java.util.List;
 public class WebMvcConfig implements WebMvcConfigurer {
 
     @Bean
-    public RequireRoleInterceptor requireRoleInterceptor() {
-        return new RequireRoleInterceptor();
+    public AuthenticationInterceptor authenticationInterceptor() {
+        return new AuthenticationInterceptor();
+    }
+
+    @Bean
+    public AuthorizationInterceptor authorizationInterceptor() {
+        return new AuthorizationInterceptor();
     }
 
     @Bean
@@ -31,8 +37,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(requireRoleInterceptor())
-                .addPathPatterns("/api/**");
+        registry.addInterceptor(authenticationInterceptor())
+                .addPathPatterns("/api/**")
+                .order(1);
+
+        registry.addInterceptor(authorizationInterceptor())
+                .addPathPatterns("/api/**")
+                .order(2);
     }
 
     @Override

--- a/src/main/java/teamssavice/ssavice/global/dto/Auth.java
+++ b/src/main/java/teamssavice/ssavice/global/dto/Auth.java
@@ -1,0 +1,9 @@
+package teamssavice.ssavice.global.dto;
+
+import teamssavice.ssavice.auth.constants.Role;
+
+public record Auth(
+    Long id,
+    Role role
+) {
+}

--- a/src/main/java/teamssavice/ssavice/global/dto/Auth.java
+++ b/src/main/java/teamssavice/ssavice/global/dto/Auth.java
@@ -6,4 +6,11 @@ public record Auth(
     Long id,
     Role role
 ) {
+    public Long getIdIfCanAccess(Role required) {
+        return canAccess(required) ? id : null;
+    }
+
+    public boolean canAccess(Role required) {
+        return required.canAccess(role);
+    }
 }

--- a/src/main/java/teamssavice/ssavice/global/filter/JwtAuthFilter.java
+++ b/src/main/java/teamssavice/ssavice/global/filter/JwtAuthFilter.java
@@ -11,7 +11,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.filter.OncePerRequestFilter;
 import teamssavice.ssavice.auth.TokenProvider;
-import teamssavice.ssavice.auth.constants.Role;
 import teamssavice.ssavice.global.exception.CustomException;
 
 import java.io.IOException;
@@ -33,8 +32,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             if(accessToken != null) {
                 Claims claims = tokenProvider.getClaim(accessToken);
                 request.setAttribute("sub", claims.getSubject());
-                Role role = Role.valueOf(claims.get("role", String.class));
-                request.setAttribute("role", role);
+                request.setAttribute("role", claims.get("role", String.class));
             }
 
             filterChain.doFilter(request, response);

--- a/src/main/java/teamssavice/ssavice/global/filter/JwtAuthFilter.java
+++ b/src/main/java/teamssavice/ssavice/global/filter/JwtAuthFilter.java
@@ -12,24 +12,14 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.web.filter.OncePerRequestFilter;
 import teamssavice.ssavice.auth.TokenProvider;
 import teamssavice.ssavice.auth.constants.Role;
-import teamssavice.ssavice.global.constants.ErrorCode;
-import teamssavice.ssavice.global.exception.AuthenticationException;
 import teamssavice.ssavice.global.exception.CustomException;
 
 import java.io.IOException;
-import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
     private static final String HEADER_AUTHORIZATION = "Authorization";
     private static final String TOKEN_PREFIX = "Bearer ";
-    private static final List<String> EXCLUDE_URLS = List.of(
-            "/api/user/login",
-            "/api/company/login",
-            "/api/auth/token/refresh",
-            "/api/auth/logout",
-            "/api/health"
-    );
     private final TokenProvider tokenProvider;
 
     @Override
@@ -38,13 +28,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
+        String accessToken = resolveToken(request);
         try {
-            String accessToken = resolveToken(request);
-
-            Claims claims = tokenProvider.getClaim(accessToken);
-            request.setAttribute("sub", claims.getSubject());
-            Role role = Role.valueOf(claims.get("role", String.class));
-            request.setAttribute("role", role);
+            if(accessToken != null) {
+                Claims claims = tokenProvider.getClaim(accessToken);
+                request.setAttribute("sub", claims.getSubject());
+                Role role = Role.valueOf(claims.get("role", String.class));
+                request.setAttribute("role", role);
+            }
 
             filterChain.doFilter(request, response);
         } catch (CustomException e) {
@@ -52,19 +43,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         }
     }
 
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        String url = request.getRequestURI();
-
-        return EXCLUDE_URLS.stream()
-                .anyMatch(url::startsWith);
-    }
-
     private String resolveToken(HttpServletRequest request) {
         String authHeader = request.getHeader(HEADER_AUTHORIZATION);
 
         if (authHeader == null || !authHeader.startsWith(TOKEN_PREFIX)) {
-            throw new AuthenticationException(ErrorCode.MISSING_TOKEN);
+            return null;
         }
 
         return authHeader.substring(TOKEN_PREFIX.length());

--- a/src/main/java/teamssavice/ssavice/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/teamssavice/ssavice/global/interceptor/AuthenticationInterceptor.java
@@ -4,7 +4,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
-import teamssavice.ssavice.auth.constants.Role;
 import teamssavice.ssavice.global.annotation.PermitAll;
 import teamssavice.ssavice.global.constants.ErrorCode;
 import teamssavice.ssavice.global.exception.AuthenticationException;
@@ -22,7 +21,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
         PermitAll permitAll = handlerMethod.getMethodAnnotation(PermitAll.class);
 
-        Role role = (Role) request.getAttribute("role");
+        String role = (String) request.getAttribute("role");
 
         if (permitAll == null && role == null) {
             throw new AuthenticationException(ErrorCode.MISSING_TOKEN);

--- a/src/main/java/teamssavice/ssavice/global/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/teamssavice/ssavice/global/interceptor/AuthenticationInterceptor.java
@@ -5,13 +5,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 import teamssavice.ssavice.auth.constants.Role;
-import teamssavice.ssavice.global.annotation.RequireRole;
+import teamssavice.ssavice.global.annotation.PermitAll;
 import teamssavice.ssavice.global.constants.ErrorCode;
-import teamssavice.ssavice.global.exception.ForbiddenException;
+import teamssavice.ssavice.global.exception.AuthenticationException;
 
-import java.util.Optional;
-
-public class RequireRoleInterceptor implements HandlerInterceptor {
+public class AuthenticationInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request,
@@ -22,14 +20,12 @@ public class RequireRoleInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        RequireRole requireRole = Optional.ofNullable(handlerMethod.getMethodAnnotation(RequireRole.class))
-                .orElse(handlerMethod.getBeanType().getAnnotation(RequireRole.class));
-        if(requireRole == null) return true;
+        PermitAll permitAll = handlerMethod.getMethodAnnotation(PermitAll.class);
 
-        Role required = requireRole.value();
         Role role = (Role) request.getAttribute("role");
-        if (!role.canAccess(required)) {
-            throw new ForbiddenException(ErrorCode.FORBIDDEN);
+
+        if (permitAll == null && role == null) {
+            throw new AuthenticationException(ErrorCode.MISSING_TOKEN);
         }
         return true;
     }

--- a/src/main/java/teamssavice/ssavice/global/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/teamssavice/ssavice/global/interceptor/AuthorizationInterceptor.java
@@ -1,0 +1,36 @@
+package teamssavice.ssavice.global.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import teamssavice.ssavice.auth.constants.Role;
+import teamssavice.ssavice.global.annotation.RequireRole;
+import teamssavice.ssavice.global.constants.ErrorCode;
+import teamssavice.ssavice.global.exception.ForbiddenException;
+
+import java.util.Optional;
+
+public class AuthorizationInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler
+    ) throws Exception {
+        if(!(handler instanceof HandlerMethod handlerMethod)) {
+            return true;
+        }
+
+        RequireRole requireRole = Optional.ofNullable(handlerMethod.getMethodAnnotation(RequireRole.class))
+                .orElse(handlerMethod.getBeanType().getAnnotation(RequireRole.class));
+        if(requireRole == null) return true;
+
+        Role required = requireRole.value();
+        Role role = (Role) request.getAttribute("role");
+        if (!role.canAccess(required)) {
+            throw new ForbiddenException(ErrorCode.FORBIDDEN);
+        }
+        return true;
+    }
+}

--- a/src/main/java/teamssavice/ssavice/global/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/teamssavice/ssavice/global/interceptor/AuthorizationInterceptor.java
@@ -27,8 +27,9 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
         if(requireRole == null) return true;
 
         Role required = requireRole.value();
-        Role role = (Role) request.getAttribute("role");
-        if (!role.canAccess(required)) {
+        String role = (String) request.getAttribute("role");
+
+        if (!required.canAccess(Role.valueOf(role))) {
             throw new ForbiddenException(ErrorCode.FORBIDDEN);
         }
         return true;

--- a/src/main/java/teamssavice/ssavice/global/resolver/CurrentAuthArgumentResolver.java
+++ b/src/main/java/teamssavice/ssavice/global/resolver/CurrentAuthArgumentResolver.java
@@ -6,14 +6,16 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
-import teamssavice.ssavice.global.annotation.CurrentId;
+import teamssavice.ssavice.auth.constants.Role;
+import teamssavice.ssavice.global.annotation.CurrentAuth;
 import teamssavice.ssavice.global.constants.ErrorCode;
+import teamssavice.ssavice.global.dto.Auth;
 import teamssavice.ssavice.global.exception.AuthenticationException;
 
-public class CurrentIdArgumentResolver implements HandlerMethodArgumentResolver {
+public class CurrentAuthArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(CurrentId.class)
+        return parameter.hasParameterAnnotation(CurrentAuth.class)
                 && parameter.getParameterType().equals(Long.class);
     }
 
@@ -24,14 +26,14 @@ public class CurrentIdArgumentResolver implements HandlerMethodArgumentResolver 
             NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory
     ) throws Exception {
-
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String sub = (String) request.getAttribute("sub");
+        String role = (String) request.getAttribute("role");
 
         if(sub == null) {
             throw new AuthenticationException(ErrorCode.MISSING_TOKEN);
         }
 
-        return Long.parseLong(sub);
+        return new Auth(Long.parseLong(sub), Role.valueOf(role));
     }
 }

--- a/src/main/java/teamssavice/ssavice/global/resolver/CurrentAuthArgumentResolver.java
+++ b/src/main/java/teamssavice/ssavice/global/resolver/CurrentAuthArgumentResolver.java
@@ -16,7 +16,7 @@ public class CurrentAuthArgumentResolver implements HandlerMethodArgumentResolve
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(CurrentAuth.class)
-                && parameter.getParameterType().equals(Long.class);
+                && parameter.getParameterType().equals(Auth.class);
     }
 
     @Override
@@ -27,11 +27,16 @@ public class CurrentAuthArgumentResolver implements HandlerMethodArgumentResolve
             WebDataBinderFactory binderFactory
     ) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        boolean required = parameter.getParameterAnnotation(CurrentAuth.class).required();
         String sub = (String) request.getAttribute("sub");
         String role = (String) request.getAttribute("role");
 
         if(sub == null) {
-            throw new AuthenticationException(ErrorCode.MISSING_TOKEN);
+            if (required) {
+                throw new AuthenticationException(ErrorCode.MISSING_TOKEN);
+            }
+            return new Auth(null, null);
         }
 
         return new Auth(Long.parseLong(sub), Role.valueOf(role));

--- a/src/main/java/teamssavice/ssavice/review/controller/ReviewController.java
+++ b/src/main/java/teamssavice/ssavice/review/controller/ReviewController.java
@@ -10,8 +10,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import teamssavice.ssavice.auth.constants.Role;
-import teamssavice.ssavice.global.annotation.CurrentId;
+import teamssavice.ssavice.global.annotation.CurrentAuth;
 import teamssavice.ssavice.global.annotation.RequireRole;
+import teamssavice.ssavice.global.dto.Auth;
 import teamssavice.ssavice.global.dto.PageResponse;
 import teamssavice.ssavice.review.controller.dto.ReviewRequest;
 import teamssavice.ssavice.review.controller.dto.ReviewResponse;
@@ -29,10 +30,10 @@ public class ReviewController {
     @PostMapping
     @RequireRole(Role.USER)
     public ResponseEntity<Void> postReview(
-            @CurrentId Long userId,
+            @CurrentAuth Auth authUser,
             @RequestBody @Valid ReviewRequest.Input request
     ) {
-        reviewService.saveReview(request.toCommand(userId));
+        reviewService.saveReview(request.toCommand(authUser.id()));
         return ResponseEntity.ok().build();
     }
 
@@ -50,10 +51,10 @@ public class ReviewController {
     @GetMapping("/company")
     @RequireRole(Role.COMPANY)
     public ResponseEntity<PageResponse<ReviewResponse.Item>> getMyCompanyReview(
-            @CurrentId Long companyId,
+            @CurrentAuth Auth authCompany,
             @PageableDefault(page = 0, size = 10) Pageable pageable
     ) {
-        Page<ReviewResponse.Item> response = reviewService.getReviewByCompanyIdPaging(ReviewCommand.RetrieveByCompanyId.of(companyId, pageable))
+        Page<ReviewResponse.Item> response = reviewService.getReviewByCompanyIdPaging(ReviewCommand.RetrieveByCompanyId.of(authCompany.id(), pageable))
                 .map(ReviewResponse.Item::from);
 
         return ResponseEntity.ok(PageResponse.from(response));
@@ -62,17 +63,16 @@ public class ReviewController {
     @GetMapping("/user")
     @RequireRole(Role.USER)
     public ResponseEntity<PageResponse<ReviewResponse.Item>> getMyReview(
-            @CurrentId Long userId,
+            @CurrentAuth Auth authUser,
             @PageableDefault(page = 0, size = 10) Pageable pageable
     ) {
-        Page<ReviewResponse.Item> response = reviewService.getReviewByUserIdPaging(ReviewCommand.RetrieveByUserId.of(userId, pageable))
+        Page<ReviewResponse.Item> response = reviewService.getReviewByUserIdPaging(ReviewCommand.RetrieveByUserId.of(authUser.id(), pageable))
                 .map(ReviewResponse.Item::from);
 
         return ResponseEntity.ok(PageResponse.from(response));
     }
 
     @GetMapping("/user/{user-id}")
-    @RequireRole(Role.USER)
     public ResponseEntity<PageResponse<ReviewResponse.Item>> getUserReview(
             @PathVariable("user-id") @Positive Long userId,
             @PageableDefault(page = 0, size = 10) Pageable pageable

--- a/src/main/java/teamssavice/ssavice/review/controller/ReviewController.java
+++ b/src/main/java/teamssavice/ssavice/review/controller/ReviewController.java
@@ -26,8 +26,8 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
-    @RequireRole(Role.USER)
     @PostMapping
+    @RequireRole(Role.USER)
     public ResponseEntity<Void> postReview(
             @CurrentId Long userId,
             @RequestBody @Valid ReviewRequest.Input request
@@ -47,8 +47,8 @@ public class ReviewController {
         return ResponseEntity.ok(PageResponse.from(response));
     }
 
-    @RequireRole(Role.COMPANY)
     @GetMapping("/company")
+    @RequireRole(Role.COMPANY)
     public ResponseEntity<PageResponse<ReviewResponse.Item>> getMyCompanyReview(
             @CurrentId Long companyId,
             @PageableDefault(page = 0, size = 10) Pageable pageable
@@ -59,8 +59,8 @@ public class ReviewController {
         return ResponseEntity.ok(PageResponse.from(response));
     }
 
-    @RequireRole(Role.USER)
     @GetMapping("/user")
+    @RequireRole(Role.USER)
     public ResponseEntity<PageResponse<ReviewResponse.Item>> getMyReview(
             @CurrentId Long userId,
             @PageableDefault(page = 0, size = 10) Pageable pageable
@@ -71,8 +71,8 @@ public class ReviewController {
         return ResponseEntity.ok(PageResponse.from(response));
     }
 
-    @RequireRole(Role.USER)
     @GetMapping("/user/{user-id}")
+    @RequireRole(Role.USER)
     public ResponseEntity<PageResponse<ReviewResponse.Item>> getUserReview(
             @PathVariable("user-id") @Positive Long userId,
             @PageableDefault(page = 0, size = 10) Pageable pageable

--- a/src/main/java/teamssavice/ssavice/serviceItem/controller/ServiceItemController.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/controller/ServiceItemController.java
@@ -3,7 +3,6 @@ package teamssavice.ssavice.serviceItem.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -55,10 +54,10 @@ public class ServiceItemController {
     public ResponseEntity<CursorResult<ServiceItemResponse.Search>> searchServiceItems(
         @ModelAttribute @Valid ServiceItemRequest.Search request,
         @RequestParam(defaultValue = "10") int size,
-        @CurrentAuth Auth authUser
+        @CurrentAuth(required = false) Auth authUser
     ) {
-        Pageable pageable = PageRequest.of(0, size);
-        CursorResult<ServiceItemModel.Search> models = serviceItemService.search(request.toCommand(authUser.id(), pageable));
+        CursorResult<ServiceItemModel.Search> models = serviceItemService.search(
+                authUser.getIdIfCanAccess(Role.USER), request.toCommand(size));
         CursorResult<ServiceItemResponse.Search> response = models.map(ServiceItemResponse.Search::from);
         return ResponseEntity.ok(response);
     }
@@ -78,9 +77,9 @@ public class ServiceItemController {
     @GetMapping("/{serviceId}")
     public ResponseEntity<ServiceItemResponse.Detail> getServiceDetail(
         @PathVariable Long serviceId,
-        @CurrentAuth Auth authUser
+        @CurrentAuth(required = false) Auth authUser
     ) {
-        ServiceItemModel.Detail model = serviceItemService.getServiceDetail(serviceId, authUser.id());
+        ServiceItemModel.Detail model = serviceItemService.getServiceDetail(serviceId, authUser.getIdIfCanAccess(Role.USER));
         return ResponseEntity.ok(ServiceItemResponse.Detail.from(model));
     }
 

--- a/src/main/java/teamssavice/ssavice/serviceItem/controller/ServiceItemController.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/controller/ServiceItemController.java
@@ -9,8 +9,10 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import teamssavice.ssavice.auth.constants.Role;
-import teamssavice.ssavice.global.annotation.CurrentId;
+import teamssavice.ssavice.global.annotation.CurrentAuth;
+import teamssavice.ssavice.global.annotation.PermitAll;
 import teamssavice.ssavice.global.annotation.RequireRole;
+import teamssavice.ssavice.global.dto.Auth;
 import teamssavice.ssavice.global.dto.CursorResult;
 import teamssavice.ssavice.global.dto.PageResponse;
 import teamssavice.ssavice.imageresource.ImageRequest;
@@ -40,23 +42,23 @@ public class ServiceItemController {
     @PostMapping
     @RequireRole(Role.COMPANY)
     public ResponseEntity<ServiceItemResponse.Register> createServiceItem(
-        @CurrentId Long companyId,
-        @RequestBody @Valid ServiceItemRequest.Create request
+            @CurrentAuth Auth authCompany,
+            @RequestBody @Valid ServiceItemRequest.Create request
     ) {
         s3Service.validateAllTempImagesOrDeleteAll(request.toValidateCommand());
-        Long serviceId = serviceItemService.register(request.toCommand(companyId));
+        Long serviceId = serviceItemService.register(request.toCommand(authCompany.id()));
         return ResponseEntity.ok(ServiceItemResponse.Register.from(serviceId));
     }
 
+    @PermitAll
     @GetMapping("/search")
-    @RequireRole(Role.USER)
     public ResponseEntity<CursorResult<ServiceItemResponse.Search>> searchServiceItems(
         @ModelAttribute @Valid ServiceItemRequest.Search request,
         @RequestParam(defaultValue = "10") int size,
-        @CurrentId Long userId
+        @CurrentAuth Auth authUser
     ) {
         Pageable pageable = PageRequest.of(0, size);
-        CursorResult<ServiceItemModel.Search> models = serviceItemService.search(request.toCommand(userId, pageable));
+        CursorResult<ServiceItemModel.Search> models = serviceItemService.search(request.toCommand(authUser.id(), pageable));
         CursorResult<ServiceItemResponse.Search> response = models.map(ServiceItemResponse.Search::from);
         return ResponseEntity.ok(response);
     }
@@ -72,26 +74,27 @@ public class ServiceItemController {
         return ResponseEntity.ok(response);
     }
 
+    @PermitAll
     @GetMapping("/{serviceId}")
-    @RequireRole(Role.USER)
     public ResponseEntity<ServiceItemResponse.Detail> getServiceDetail(
         @PathVariable Long serviceId,
-        @CurrentId Long userId
+        @CurrentAuth Auth authUser
     ) {
-        ServiceItemModel.Detail model = serviceItemService.getServiceDetail(serviceId, userId);
+        ServiceItemModel.Detail model = serviceItemService.getServiceDetail(serviceId, authUser.id());
         return ResponseEntity.ok(ServiceItemResponse.Detail.from(model));
     }
 
     @PostMapping("/image")
     @RequireRole(Role.COMPANY)
     public ResponseEntity<ImageResponse.PresignedUrls> createServiceItemPresignedUrls(
-        @CurrentId Long companyId,
+        @CurrentAuth Auth authCompany,
         @RequestBody @Valid ImageRequest.ServiceImages request
     ) {
-        List<ImageModel.PutPresignedUrl> models = imageService.updateImages(request.toCommand(companyId, ImagePath.serviceItem));
+        List<ImageModel.PutPresignedUrl> models = imageService.updateImages(request.toCommand(authCompany.id(), ImagePath.serviceItem));
         return ResponseEntity.ok(ImageResponse.PresignedUrls.from(models));
     }
 
+    @PermitAll
     @GetMapping("/company/{company-id}")
     public ResponseEntity<PageResponse<ServiceItemResponse.Summary>> getCompanysServiceItems(
         @PathVariable("company-id") Long companyId,
@@ -109,11 +112,11 @@ public class ServiceItemController {
     @GetMapping("/company/my")
     @RequireRole(Role.COMPANY)
     public ResponseEntity<PageResponse<ServiceItemResponse.Summary>> getMyCompanysServiceItems(
-        @CurrentId Long companyId,
+        @CurrentAuth Auth authCompany,
         @PageableDefault(page = 0, size = 10) Pageable pageable,
         @RequestParam("status") ServiceStatusFilter status
     ) {
-        ServiceItemCommand.RetrieveByCompanyAndStatus command = ServiceItemCommand.RetrieveByCompanyAndStatus.of(companyId, pageable, status);
+        ServiceItemCommand.RetrieveByCompanyAndStatus command = ServiceItemCommand.RetrieveByCompanyAndStatus.of(authCompany.id(), pageable, status);
 
         Page<ServiceItemResponse.Summary> responses = serviceItemService.getServiceItemByCompanyAndStatus(command)
             .map(ServiceItemResponse.Summary::from);
@@ -124,19 +127,19 @@ public class ServiceItemController {
     @GetMapping("/company/summary")
     @RequireRole(Role.COMPANY)
     public ResponseEntity<ServiceItemResponse.Count> getCompanysServiceItemCount(
-        @CurrentId Long companyId
+        @CurrentAuth Auth authCompany
     ) {
-        ServiceItemModel.Count model = serviceItemService.getCompanysServiceItemCount(companyId);
+        ServiceItemModel.Count model = serviceItemService.getCompanysServiceItemCount(authCompany.id());
         return ResponseEntity.ok(ServiceItemResponse.Count.from(model));
     }
 
     @DeleteMapping("/{serviceId}")
     @RequireRole(Role.COMPANY)
     public ResponseEntity<Void> deleteServiceItem(
-        @CurrentId Long companyId,
+        @CurrentAuth Auth authCompany,
         @PathVariable Long serviceId
     ) {
-        serviceItemService.delete(ServiceItemCommand.Delete.of(companyId, serviceId));
+        serviceItemService.delete(ServiceItemCommand.Delete.of(authCompany.id(), serviceId));
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/teamssavice/ssavice/serviceItem/controller/dto/ServiceItemRequest.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/controller/dto/ServiceItemRequest.java
@@ -2,7 +2,7 @@ package teamssavice.ssavice.serviceItem.controller.dto;
 
 import jakarta.validation.constraints.*;
 import lombok.Builder;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import teamssavice.ssavice.address.AddressRequest;
 import teamssavice.ssavice.imageresource.ImageRequest;
 import teamssavice.ssavice.s3.dto.S3Command;
@@ -83,7 +83,7 @@ public class ServiceItemRequest {
         Long lastId,
         Boolean onSale
     ) {
-        public ServiceItemCommand.Search toCommand(Long userId, Pageable pageable) {
+        public ServiceItemCommand.Search toCommand(int size) {
             return ServiceItemCommand.Search.builder()
                 .category(category)
                 .query(query)
@@ -94,9 +94,8 @@ public class ServiceItemRequest {
                 .maxPrice(maxPrice)
                 .sortBy(sortBy)
                 .lastId(lastId)
-                .pageable(pageable)
+                .pageable(PageRequest.of(0, size))
                 .onSale(Boolean.TRUE.equals(onSale))
-                .userId(userId)
                 .build();
         }
     }

--- a/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemService.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemService.java
@@ -32,6 +32,7 @@ import teamssavice.ssavice.serviceItem.service.dto.ServiceItemModel;
 import teamssavice.ssavice.wish.service.WishReadService;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -81,7 +82,9 @@ public class ServiceItemService {
     public CursorResult<ServiceItemModel.Search> search(@Nullable Long userId, ServiceItemCommand.Search command) {
 
         Slice<ServiceItem> items = serviceItemReadService.search(command);
-        Set<Long> set = bookReadService.findReservedServiceItemIdsFromLatestBooks(userId, items.getContent());
+        Set<Long> set = (userId != null)
+                ? bookReadService.findReservedServiceItemIdsFromLatestBooks(userId, items.getContent())
+                : Collections.emptySet();
 
         List<ServiceItemModel.Search> content = items.getContent().stream()
             .map(entity -> ServiceItemModel.Search.from(entity, set.contains(entity.getId()),
@@ -105,8 +108,8 @@ public class ServiceItemService {
             imageUrls.add(s3Service.generateGetPresignedUrl(imageResource.getResolveKey()));
         }
 
-        boolean isLiked = wishReadService.existsByUserIdAndServiceItemId(userId, serviceId);
-        boolean isBooked = bookReadService.isBookedByUserIdAndServiceId(userId, serviceId);
+        boolean isLiked = (userId != null) && wishReadService.existsByUserIdAndServiceItemId(userId, serviceId);
+        boolean isBooked = (userId != null) && bookReadService.isBookedByUserIdAndServiceId(userId, serviceId);
 
         return ServiceItemModel.Detail.from(serviceItem, imageUrls, isLiked, isBooked);
     }

--- a/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemService.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/service/ServiceItemService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamssavice.ssavice.address.AddressCommand;
@@ -77,10 +78,10 @@ public class ServiceItemService {
     }
 
     @Transactional(readOnly = true)
-    public CursorResult<ServiceItemModel.Search> search(ServiceItemCommand.Search command) {
+    public CursorResult<ServiceItemModel.Search> search(@Nullable Long userId, ServiceItemCommand.Search command) {
 
         Slice<ServiceItem> items = serviceItemReadService.search(command);
-        Set<Long> set = bookReadService.findReservedServiceItemIdsFromLatestBooks(command.userId(), items.getContent());
+        Set<Long> set = bookReadService.findReservedServiceItemIdsFromLatestBooks(userId, items.getContent());
 
         List<ServiceItemModel.Search> content = items.getContent().stream()
             .map(entity -> ServiceItemModel.Search.from(entity, set.contains(entity.getId()),
@@ -96,7 +97,7 @@ public class ServiceItemService {
     }
 
     @Transactional(readOnly = true)
-    public ServiceItemModel.Detail getServiceDetail(Long serviceId, Long userId) {
+    public ServiceItemModel.Detail getServiceDetail(Long serviceId, @Nullable Long userId) {
         ServiceItem serviceItem = serviceItemReadService.findByIdWithAddressAndImageList(serviceId);
         List<ImageResource> imageList = imageReadService.findAllById(serviceItem.getImageIds());
         List<String> imageUrls = new ArrayList<>();

--- a/src/main/java/teamssavice/ssavice/serviceItem/service/dto/ServiceItemCommand.java
+++ b/src/main/java/teamssavice/ssavice/serviceItem/service/dto/ServiceItemCommand.java
@@ -49,8 +49,7 @@ public class ServiceItemCommand {
         Integer sortBy,
         Long lastId,      // 커서 ID
         Pageable pageable,
-        boolean onSale,
-        Long userId
+        boolean onSale
     ) {
     }
 

--- a/src/main/java/teamssavice/ssavice/user/controller/UserController.java
+++ b/src/main/java/teamssavice/ssavice/user/controller/UserController.java
@@ -46,6 +46,7 @@ public class UserController {
     }
 
     @GetMapping("/profile")
+    @RequireRole(Role.USER)
     public ResponseEntity<UserResponse.Info> profile(
         @CurrentId Long userId
     ) {
@@ -55,6 +56,7 @@ public class UserController {
     }
 
     @PostMapping("/profile")
+    @RequireRole(Role.USER)
     public ResponseEntity<UserResponse.Summary> Modify(
         @CurrentId Long userId,
         @RequestBody @Valid UserRequest.Modify request

--- a/src/main/java/teamssavice/ssavice/user/controller/UserController.java
+++ b/src/main/java/teamssavice/ssavice/user/controller/UserController.java
@@ -13,9 +13,10 @@ import teamssavice.ssavice.address.AddressModel;
 import teamssavice.ssavice.address.AddressRequest;
 import teamssavice.ssavice.address.AddressResponse;
 import teamssavice.ssavice.auth.constants.Role;
-import teamssavice.ssavice.global.annotation.CurrentId;
+import teamssavice.ssavice.global.annotation.CurrentAuth;
 import teamssavice.ssavice.global.annotation.PermitAll;
 import teamssavice.ssavice.global.annotation.RequireRole;
+import teamssavice.ssavice.global.dto.Auth;
 import teamssavice.ssavice.imageresource.ImageRequest;
 import teamssavice.ssavice.imageresource.ImageResponse;
 import teamssavice.ssavice.imageresource.constants.ImageContentType;
@@ -50,9 +51,9 @@ public class UserController {
     @GetMapping("/profile")
     @RequireRole(Role.USER)
     public ResponseEntity<UserResponse.Info> profile(
-        @CurrentId Long userId
+        @CurrentAuth Auth authUser
     ) {
-        UserModel.Info model = userService.getProfile(userId);
+        UserModel.Info model = userService.getProfile(authUser.id());
 
         return ResponseEntity.ok(UserResponse.Info.from(model));
     }
@@ -60,10 +61,10 @@ public class UserController {
     @PostMapping("/profile")
     @RequireRole(Role.USER)
     public ResponseEntity<UserResponse.Summary> Modify(
-        @CurrentId Long userId,
+        @CurrentAuth Auth authUser,
         @RequestBody @Valid UserRequest.Modify request
     ) {
-        UserModel.Modify model = userService.modifyProfile(request.toCommand(userId));
+        UserModel.Modify model = userService.modifyProfile(request.toCommand(authUser.id()));
 
         return ResponseEntity.ok(UserResponse.Summary.from(model));
     }
@@ -71,10 +72,10 @@ public class UserController {
     @PostMapping("/profile/image")
     @RequireRole(Role.USER)
     public ResponseEntity<ImageResponse.PresignedUrl> createProfilePresignedUrl(
-        @CurrentId Long userId,
+        @CurrentAuth Auth authUser,
         @RequestBody @Valid ImageRequest.ContentType request
     ) {
-        ImageModel.PutPresignedUrl model = imageService.updateImage(userId, ImagePath.profile,
+        ImageModel.PutPresignedUrl model = imageService.updateImage(authUser.id(), ImagePath.profile,
             ImageContentType.from(request.contentType()));
         return ResponseEntity.ok(ImageResponse.PresignedUrl.from(model));
     }
@@ -82,30 +83,30 @@ public class UserController {
     @PostMapping("/profile/image/confirm")
     @RequireRole(Role.USER)
     public ResponseEntity<Void> confirmProfileImageUpload(
-        @CurrentId Long userId,
+        @CurrentAuth Auth authUser,
         @RequestBody @Valid ImageRequest.Confirm request
     ) {
         s3Service.validateTempImageOrDelete(request.objectKey());
-        userService.updateProfileImage(userId, request.objectKey());
+        userService.updateProfileImage(authUser.id(), request.objectKey());
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/address")
     @RequireRole(Role.USER)
     public ResponseEntity<AddressResponse.RegionDetail> getAddress(
-        @CurrentId Long userId
+        @CurrentAuth Auth authUser
     ) {
-        AddressModel.RegionDetail model = userService.getUserAddress(userId);
+        AddressModel.RegionDetail model = userService.getUserAddress(authUser.id());
         return ResponseEntity.ok(AddressResponse.RegionDetail.from(model));
     }
 
     @PatchMapping("/address")
     @RequireRole(Role.USER)
     public ResponseEntity<AddressResponse.RegionDetail> patchAddress(
-        @CurrentId Long userId,
+        @CurrentAuth Auth authUser,
         @RequestBody @Valid AddressRequest.Region request
     ) {
-        AddressModel.RegionDetail model = userService.updateUserAddress(request.toCommand(userId));
+        AddressModel.RegionDetail model = userService.updateUserAddress(request.toCommand(authUser.id()));
         return ResponseEntity.ok(AddressResponse.RegionDetail.from(model));
     }
 }

--- a/src/main/java/teamssavice/ssavice/user/controller/UserController.java
+++ b/src/main/java/teamssavice/ssavice/user/controller/UserController.java
@@ -14,6 +14,7 @@ import teamssavice.ssavice.address.AddressRequest;
 import teamssavice.ssavice.address.AddressResponse;
 import teamssavice.ssavice.auth.constants.Role;
 import teamssavice.ssavice.global.annotation.CurrentId;
+import teamssavice.ssavice.global.annotation.PermitAll;
 import teamssavice.ssavice.global.annotation.RequireRole;
 import teamssavice.ssavice.imageresource.ImageRequest;
 import teamssavice.ssavice.imageresource.ImageResponse;
@@ -36,6 +37,7 @@ public class UserController {
     private final ImageService imageService;
     private final S3Service s3Service;
 
+    @PermitAll
     @PostMapping("/login")
     public ResponseEntity<UserResponse.Login> login(
         @RequestBody @Valid UserRequest.Login request

--- a/src/main/java/teamssavice/ssavice/wish/controller/WishController.java
+++ b/src/main/java/teamssavice/ssavice/wish/controller/WishController.java
@@ -8,8 +8,9 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import teamssavice.ssavice.auth.constants.Role;
-import teamssavice.ssavice.global.annotation.CurrentId;
+import teamssavice.ssavice.global.annotation.CurrentAuth;
 import teamssavice.ssavice.global.annotation.RequireRole;
+import teamssavice.ssavice.global.dto.Auth;
 import teamssavice.ssavice.global.dto.PageResponse;
 import teamssavice.ssavice.wish.controller.dto.WishRequest;
 import teamssavice.ssavice.wish.controller.dto.WishResponse;
@@ -27,23 +28,23 @@ public class WishController {
     @PostMapping("/{serviceId}")
     @RequireRole(Role.USER)
     public ResponseEntity<Void> updateWishStatus(
-            @CurrentId Long userId,
+            @CurrentAuth Auth authUser,
             @PathVariable Long serviceId,
             @RequestBody @Valid WishRequest.Update request
     ) {
 
-        wishService.updateWishStatus(request.toCommand(userId, serviceId));
+        wishService.updateWishStatus(request.toCommand(authUser.id(), serviceId));
         return ResponseEntity.ok().build();
     }
 
     @GetMapping
     @RequireRole(Role.USER)
     public ResponseEntity<PageResponse<WishResponse.Summary>> getMyWishList(
-            @CurrentId Long userId,
+            @CurrentAuth Auth authUser,
             @PageableDefault(page = 0, size = 10) Pageable pageable
     ) {
 
-        WishCommand.Retrieve command = WishCommand.Retrieve.of(userId, pageable);
+        WishCommand.Retrieve command = WishCommand.Retrieve.of(authUser.id(), pageable);
 
         Page<WishModel.Summary> modelPage = wishService.getWishList(command);
         Page<WishResponse.Summary> responses = modelPage.map(WishResponse.Summary::from);

--- a/src/main/java/teamssavice/ssavice/wish/service/WishReadService.java
+++ b/src/main/java/teamssavice/ssavice/wish/service/WishReadService.java
@@ -4,6 +4,7 @@ package teamssavice.ssavice.wish.service;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamssavice.ssavice.wish.entity.Wish;
@@ -30,8 +31,8 @@ public class WishReadService {
     }
 
     @Transactional(readOnly = true)
-    public boolean existsByUserIdAndServiceItemId(Long userId, Long serviceId) {
-
+    public boolean existsByUserIdAndServiceItemId(@Nullable Long userId, Long serviceId) {
+        if(userId == null) return false;
         return wishRepository.existsByUserIdAndServiceItemId(userId, serviceId);
     }
 

--- a/src/main/java/teamssavice/ssavice/wish/service/WishReadService.java
+++ b/src/main/java/teamssavice/ssavice/wish/service/WishReadService.java
@@ -1,15 +1,15 @@
 package teamssavice.ssavice.wish.service;
 
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamssavice.ssavice.wish.entity.Wish;
 import teamssavice.ssavice.wish.infrastructure.WishRepository;
 import teamssavice.ssavice.wish.service.dto.WishCommand;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,8 +31,7 @@ public class WishReadService {
     }
 
     @Transactional(readOnly = true)
-    public boolean existsByUserIdAndServiceItemId(@Nullable Long userId, Long serviceId) {
-        if(userId == null) return false;
+    public boolean existsByUserIdAndServiceItemId(Long userId, Long serviceId) {
         return wishRepository.existsByUserIdAndServiceItemId(userId, serviceId);
     }
 

--- a/src/test/java/teamssavice/ssavice/serviceItem/controller/ServiceItemControllerTest.java
+++ b/src/test/java/teamssavice/ssavice/serviceItem/controller/ServiceItemControllerTest.java
@@ -1,6 +1,5 @@
 package teamssavice.ssavice.serviceItem.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -9,7 +8,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import teamssavice.ssavice.address.AddressRequest;
+import teamssavice.ssavice.auth.constants.Role;
 import teamssavice.ssavice.global.constants.ErrorCode;
+import teamssavice.ssavice.global.dto.Auth;
 import teamssavice.ssavice.global.exception.EntityNotFoundException;
 import teamssavice.ssavice.global.exception.ImageSizeException;
 import teamssavice.ssavice.imageresource.ImageRequest;
@@ -54,13 +55,14 @@ class ServiceItemControllerTest {
             // given
             Long companyId = 1L;
             Long serviceId = 100L;
+            Auth authCompany = new Auth(companyId, Role.COMPANY);
 
             ServiceItemRequest.Create request = createValidRequest();
             willDoNothing().given(s3Service).validateAllTempImagesOrDeleteAll(any(S3Command.ValidateKeys.class));
             given(serviceItemService.register(any())).willReturn(serviceId);
 
             // when
-            ServiceItemResponse.Register response = serviceItemController.createServiceItem(companyId, request).getBody();
+            ServiceItemResponse.Register response = serviceItemController.createServiceItem(authCompany, request).getBody();
 
             // then
             assertThat(response).isNotNull();
@@ -74,13 +76,14 @@ class ServiceItemControllerTest {
         void 이미지_검증_실패_EntityNotFoundException() {
             // given
             Long companyId = 1L;
+            Auth authCompany = new Auth(companyId, Role.COMPANY);
             ServiceItemRequest.Create request = createValidRequest();
 
             willThrow(new EntityNotFoundException(ErrorCode.IMAGE_NOT_FOUND))
                     .given(s3Service).validateAllTempImagesOrDeleteAll(any(S3Command.ValidateKeys.class));
 
             // when & then
-            assertThatThrownBy(() -> serviceItemController.createServiceItem(companyId, request))
+            assertThatThrownBy(() -> serviceItemController.createServiceItem(authCompany, request))
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.IMAGE_NOT_FOUND);
 
@@ -94,13 +97,14 @@ class ServiceItemControllerTest {
         void 이미지_검증_실패_ImageSizeException() {
             // given
             Long companyId = 1L;
+            Auth authCompany = new Auth(companyId, Role.COMPANY);
             ServiceItemRequest.Create request = createValidRequest();
 
             willThrow(new ImageSizeException(ErrorCode.IMAGE_TOO_LARGE, 10_000_000L, 5_242_880L))
                     .given(s3Service).validateAllTempImagesOrDeleteAll(any(S3Command.ValidateKeys.class));
 
             // when & then
-            assertThatThrownBy(() -> serviceItemController.createServiceItem(companyId, request))
+            assertThatThrownBy(() -> serviceItemController.createServiceItem(authCompany, request))
                     .isInstanceOf(ImageSizeException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.IMAGE_TOO_LARGE);
 


### PR DESCRIPTION
## 🔎 작업 내용
* 인증 절차 변경
### Filter: JWT 토큰의 유효성 검 및 attribute에 매핑
### AuthenticationInterceptor: PermitAll이 아닌데도 불구하고 JWT가 비어있는지 여부 확
### AuthorizationInterceptor: 특정 Role 접근 권한 확인
### CurrentAuthArgumentResolver: 컨트롤러 메서드에서 바로 사용할 수 있도록 Auth 객체 생성. 이때 CurrentAuth의 required 옵션을 체크

### PermitAll: JWT가 필요없다는 어노테이션

## 이미지 첨부

<!--- 
관련 이미지가 있다면 첨부해주세요.
복잡한 도메인로직이 있다면 플로우차트로 표현해주세요.
--->

## To Reviewers 📢
<!-- 리뷰어에게 질문할 사항이나 추가 설명, 요청이 필요한 부분을 여기에 적어주세요. -->

## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #126 
